### PR TITLE
ARXIVNG-1701 add class to manual HTML table

### DIFF
--- a/help/prep.md
+++ b/help/prep.md
@@ -351,7 +351,7 @@ Two methods are supported for entering accented characters into arXiv.
 Here are the <span class="mathjax">La$\\TeX$</span> accents commands that can be used in the Title and
 Authors fields.
 
-<table border="1" cellpadding="3">
+<table class="table is-striped">
 <tr><td ><b>&#196;</b>&nbsp;&nbsp;&nbsp;\"A</td><td ><b>&#228;</b>&nbsp;&nbsp;&nbsp;\"a</td><td ><b>&#193;</b>&nbsp;&nbsp;&nbsp;\'A</td><td ><b>&#225;</b>&nbsp;&nbsp;&nbsp;\'a</td><td ><b>&#550;</b>&nbsp;&nbsp;&nbsp;\.A</td><td ><b>&#551;</b>&nbsp;&nbsp;&nbsp;\.a</td><td ><b>&#256;</b>&nbsp;&nbsp;&nbsp;\=A</td></tr>
 <tr><td ><b>&#257;</b>&nbsp;&nbsp;&nbsp;\=a</td><td ><b>&#194;</b>&nbsp;&nbsp;&nbsp;\^A</td><td ><b>&#226;</b>&nbsp;&nbsp;&nbsp;\^a</td><td ><b>&#192;</b>&nbsp;&nbsp;&nbsp;\`A</td><td ><b>&#224;</b>&nbsp;&nbsp;&nbsp;\`a</td><td ><b>&#260;</b>&nbsp;&nbsp;&nbsp;\k{A}</td><td ><b>&#261;</b>&nbsp;&nbsp;&nbsp;\k{a}</td></tr>
 <tr><td ><b>&#197;</b>&nbsp;&nbsp;&nbsp;\r{A}</td><td ><b>&#229;</b>&nbsp;&nbsp;&nbsp;\r{a}</td><td ><b>&#258;</b>&nbsp;&nbsp;&nbsp;\u{A}</td><td ><b>&#259;</b>&nbsp;&nbsp;&nbsp;\u{a}</td><td ><b>&#461;</b>&nbsp;&nbsp;&nbsp;\v{A}</td><td ><b>&#462;</b>&nbsp;&nbsp;&nbsp;\v{a}</td><td ><b>&#195;</b>&nbsp;&nbsp;&nbsp;\~A</td></tr>


### PR DESCRIPTION
adding these classes to an HTML table will apply the arXiv global styling and keep things consistent and pretty. Didn't have time to build, sorry!

<img width="599" alt="screen shot 2019-02-08 at 10 56 54 am" src="https://user-images.githubusercontent.com/17456668/52489438-48e89d80-2b90-11e9-8b1c-bae633cee741.png">
