### PR TITLE
drop extra wording

### DIFF
--- a/help/contact.md
+++ b/help/contact.md
@@ -9,36 +9,22 @@ Information about institutional membership or contributions to arXiv can be foun
 
 If you have questions about paper submission, accounts, and use of arXiv, review [help](/help) and [FAQ](/help/faq). If you require further assistance, contact us at <help@arxiv.org>. 
 
-When contacting arXiv administrators, please include a detailed description of your problem. Note that arXiv help and moderation email addresses are monitored between 0900-1700 EST/EDT, Monday through Friday, subject to
-administrator availability and the holiday schedule.
+Note that arXiv help and moderation email addresses are monitored between 0900-1700 EST/EDT, Monday through Friday, subject to administrator availability and the holiday schedule.
 
 **To avoid a long delay in receiving a response:** 
 
--   Send a precise email including all relevant details (especially paper ids, rejection ids, URLs, etc.).
+-   Send a precise email including all relevant details (especially submission or paper ids, rejection ids, URLs, etc.).
 -   If you receive an automated response to your email, please read all instructions carefully.
     -   If there is no other identifying information in your message
         (e.g., paper id or rejection id), you may need to address your
         email with **"Dear arXiv,"** to bypass our SPAM filter.
--   *Do not include attachments with your email.*
-    -   If your submission has failed, quote the rejection identifier in
-        your email.
-    -   If you need to correct files in your submission, [make a
-        replacement](replace).
-    -   If you feel that a file is necessary to explain your problem,
-        first send an email with as many details as possible and ask if
-        the attachment is truly necessary.
--   *Always* contact arXiv administrators before your submission is
-    [announced](versions) if there is a technical problem that
-    prevents processing.
 
 ## Moderation queries
 
 If you have questions about the status of your submission, contact us at <moderation@arxiv.org>.
  
--   Send a precise email, including all relevant details (especially
-    paper ids, former correspondence, submission summaries, etc.)
--   If you receive an automated response to your email, please read all
-    instructions carefully.
+-   Send a precise email, including all relevant details (especially paper ids, former correspondence, submission summaries, etc.)
+-   If you receive an automated response to your email, please read all instructions carefully.
     -   If there is no other identifying information in your message
         (e.g., paper id or rejection id), you may need to address your
         email with **"Dear arXiv-moderation,"** to bypass our SPAM


### PR DESCRIPTION
If we start noticing repeated user problems with attachments we can add that lingo back in here.