### PR TITLE
ARXIVNG-1795 auto deployment

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "markdown"]
-	path = markdown
-	url = git@github.com:arXiv/arxiv-markdown.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,118 @@
+language: python
+sudo: required
+services:
+- docker
+cache: pip
+os:
+- linux
+python:
+- '3.6'
+script:
+- pip install pipenv
+- pipenv install arxiv-marxdown
+
+deploy:
+# Deploy commits on working branches to development, named based on the branch
+# name.
+- provider: script
+  script:
+    SITE_HUMAN_NAME="arXiv Help Pages" SITE_HUMAN_SHORT_NAME=Help SITE_SEARCH_ENABLED=1 ./make_and_push_image.sh help &&
+    ./deploy.sh marxdown development help
+  on:
+    all_branches: true
+    condition: $TRAVIS_BRANCH != master && $TRAVIS_BRANCH != develop
+- provider: script
+  script:
+    SITE_HUMAN_NAME="Computing Research Repository" SITE_HUMAN_SHORT_NAME=CoRR SITE_SEARCH_ENABLED=0 ./make_and_push_image.sh corr &&
+    ./deploy.sh marxdown development corr
+  on:
+    all_branches: true
+    condition: $TRAVIS_BRANCH != master && $TRAVIS_BRANCH != develop
+- provider: script
+  script:
+    SITE_HUMAN_NAME="HyperTeX Documentation" SITE_HUMAN_SHORT_NAME=HyperTeX ./make_and_push_image.sh hypertex &&
+    ./deploy.sh marxdown development hypertex
+  on:
+    all_branches: true
+    condition: $TRAVIS_BRANCH != master && $TRAVIS_BRANCH != develop
+- provider: script
+  script:
+    SITE_HUMAN_NAME="About arXiv" SITE_HUMAN_SHORT_NAME=About ./make_and_push_image.sh about &&
+    ./deploy.sh marxdown development about
+  on:
+    all_branches: true
+    condition: $TRAVIS_BRANCH != master && $TRAVIS_BRANCH != develop
+- provider: script
+  script:
+    SITE_HUMAN_NAME="arXiv Labs" SITE_HUMAN_SHORT_NAME=Labs ./make_and_push_image.sh labs &&
+    ./deploy.sh marxdown development labs
+  on:
+    all_branches: true
+    condition: $TRAVIS_BRANCH != master && $TRAVIS_BRANCH != develop
+
+# Deploy tagged commits to staging.
+- provider: script
+  script:
+    SITE_HUMAN_NAME="arXiv Help Pages" SITE_HUMAN_SHORT_NAME=Help SITE_SEARCH_ENABLED=1 ./make_and_push_image.sh help &&
+    ./deploy.sh marxdown staging help
+  on:
+    tags: true
+- provider: script
+  script:
+    SITE_HUMAN_NAME="Computing Research Repository" SITE_HUMAN_SHORT_NAME=CoRR SITE_SEARCH_ENABLED=0 ./make_and_push_image.sh corr &&
+    ./deploy.sh marxdown staging corr
+  on:
+    tags: true
+- provider: script
+  script:
+    SITE_HUMAN_NAME="HyperTeX Documentation" SITE_HUMAN_SHORT_NAME=HyperTeX ./make_and_push_image.sh hypertex &&
+    ./deploy.sh marxdown staging hypertex
+  on:
+    tags: true
+- provider: script
+  script:
+    SITE_HUMAN_NAME="About arXiv" SITE_HUMAN_SHORT_NAME=About ./make_and_push_image.sh about &&
+    ./deploy.sh marxdown staging about
+  on:
+    tags: true
+- provider: script
+  script:
+    SITE_HUMAN_NAME="arXiv Labs" SITE_HUMAN_SHORT_NAME=Labs ./make_and_push_image.sh labs &&
+    ./deploy.sh marxdown staging labs
+  on:
+    tags: true
+
+
+# Deploy the develop branch to development.
+- provider: script
+  script:
+    SITE_HUMAN_NAME="arXiv Help Pages" SITE_HUMAN_SHORT_NAME=Help SITE_SEARCH_ENABLED=1 ./make_and_push_image.sh help &&
+    ./deploy.sh marxdown development help
+  on:
+    branch: development
+- provider: script
+  script:
+    SITE_HUMAN_NAME="Computing Research Repository" SITE_HUMAN_SHORT_NAME=CoRR SITE_SEARCH_ENABLED=0 ./make_and_push_image.sh corr &&
+    ./deploy.sh marxdown development corr
+  on:
+    branch: development
+
+- provider: script
+  script:
+    SITE_HUMAN_NAME="HyperTeX Documentation" SITE_HUMAN_SHORT_NAME=HyperTeX ./make_and_push_image.sh hypertex &&
+    ./deploy.sh marxdown development hypertex
+  on:
+    branch: development
+
+- provider: script
+  script:
+    SITE_HUMAN_NAME="About arXiv" SITE_HUMAN_SHORT_NAME=About ./make_and_push_image.sh about &&
+    ./deploy.sh marxdown development about
+  on:
+    branch: development
+- provider: script
+  script:
+    SITE_HUMAN_NAME="arXiv Labs" SITE_HUMAN_SHORT_NAME=Labs ./make_and_push_image.sh labs &&
+    ./deploy.sh marxdown development labs
+  on:
+    branch: development

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,35 +17,35 @@ deploy:
 - provider: script
   script:
     SITE_HUMAN_NAME="arXiv Help Pages" SITE_HUMAN_SHORT_NAME=Help SITE_SEARCH_ENABLED=1 ./make_and_push_image.sh help &&
-    ./deploy.sh marxdown development help
+    SITE_SEARCH_ENABLED=1 ./deploy.sh marxdown development help
   on:
     all_branches: true
     condition: $TRAVIS_BRANCH != master && $TRAVIS_BRANCH != develop
 - provider: script
   script:
     SITE_HUMAN_NAME="Computing Research Repository" SITE_HUMAN_SHORT_NAME=CoRR SITE_SEARCH_ENABLED=0 ./make_and_push_image.sh corr &&
-    ./deploy.sh marxdown development corr
+    SITE_SEARCH_ENABLED=0 ./deploy.sh marxdown development corr
   on:
     all_branches: true
     condition: $TRAVIS_BRANCH != master && $TRAVIS_BRANCH != develop
 - provider: script
   script:
     SITE_HUMAN_NAME="HyperTeX Documentation" SITE_HUMAN_SHORT_NAME=HyperTeX ./make_and_push_image.sh hypertex &&
-    ./deploy.sh marxdown development hypertex
+    SITE_SEARCH_ENABLED=0 ./deploy.sh marxdown development hypertex
   on:
     all_branches: true
     condition: $TRAVIS_BRANCH != master && $TRAVIS_BRANCH != develop
 - provider: script
   script:
     SITE_HUMAN_NAME="About arXiv" SITE_HUMAN_SHORT_NAME=About ./make_and_push_image.sh about &&
-    ./deploy.sh marxdown development about
+    SITE_SEARCH_ENABLED=0 ./deploy.sh marxdown development about
   on:
     all_branches: true
     condition: $TRAVIS_BRANCH != master && $TRAVIS_BRANCH != develop
 - provider: script
   script:
     SITE_HUMAN_NAME="arXiv Labs" SITE_HUMAN_SHORT_NAME=Labs ./make_and_push_image.sh labs &&
-    ./deploy.sh marxdown development labs
+    SITE_SEARCH_ENABLED=0 ./deploy.sh marxdown development labs
   on:
     all_branches: true
     condition: $TRAVIS_BRANCH != master && $TRAVIS_BRANCH != develop
@@ -54,31 +54,31 @@ deploy:
 - provider: script
   script:
     SITE_HUMAN_NAME="arXiv Help Pages" SITE_HUMAN_SHORT_NAME=Help SITE_SEARCH_ENABLED=1 ./make_and_push_image.sh help &&
-    ./deploy.sh marxdown staging help
+    SITE_SEARCH_ENABLED=1 ./deploy.sh marxdown staging help
   on:
     tags: true
 - provider: script
   script:
     SITE_HUMAN_NAME="Computing Research Repository" SITE_HUMAN_SHORT_NAME=CoRR SITE_SEARCH_ENABLED=0 ./make_and_push_image.sh corr &&
-    ./deploy.sh marxdown staging corr
+    SITE_SEARCH_ENABLED=0 ./deploy.sh marxdown staging corr
   on:
     tags: true
 - provider: script
   script:
     SITE_HUMAN_NAME="HyperTeX Documentation" SITE_HUMAN_SHORT_NAME=HyperTeX ./make_and_push_image.sh hypertex &&
-    ./deploy.sh marxdown staging hypertex
+    SITE_SEARCH_ENABLED=0 ./deploy.sh marxdown staging hypertex
   on:
     tags: true
 - provider: script
   script:
     SITE_HUMAN_NAME="About arXiv" SITE_HUMAN_SHORT_NAME=About ./make_and_push_image.sh about &&
-    ./deploy.sh marxdown staging about
+    SITE_SEARCH_ENABLED=0 ./deploy.sh marxdown staging about
   on:
     tags: true
 - provider: script
   script:
     SITE_HUMAN_NAME="arXiv Labs" SITE_HUMAN_SHORT_NAME=Labs ./make_and_push_image.sh labs &&
-    ./deploy.sh marxdown staging labs
+    SITE_SEARCH_ENABLED=0 ./deploy.sh marxdown staging labs
   on:
     tags: true
 
@@ -87,32 +87,32 @@ deploy:
 - provider: script
   script:
     SITE_HUMAN_NAME="arXiv Help Pages" SITE_HUMAN_SHORT_NAME=Help SITE_SEARCH_ENABLED=1 ./make_and_push_image.sh help &&
-    ./deploy.sh marxdown development help
+    SITE_SEARCH_ENABLED=1 ./deploy.sh marxdown development help
   on:
     branch: development
 - provider: script
   script:
     SITE_HUMAN_NAME="Computing Research Repository" SITE_HUMAN_SHORT_NAME=CoRR SITE_SEARCH_ENABLED=0 ./make_and_push_image.sh corr &&
-    ./deploy.sh marxdown development corr
+    SITE_SEARCH_ENABLED=0 ./deploy.sh marxdown development corr
   on:
     branch: development
 
 - provider: script
   script:
     SITE_HUMAN_NAME="HyperTeX Documentation" SITE_HUMAN_SHORT_NAME=HyperTeX ./make_and_push_image.sh hypertex &&
-    ./deploy.sh marxdown development hypertex
+    SITE_SEARCH_ENABLED=0 ./deploy.sh marxdown development hypertex
   on:
     branch: development
 
 - provider: script
   script:
     SITE_HUMAN_NAME="About arXiv" SITE_HUMAN_SHORT_NAME=About ./make_and_push_image.sh about &&
-    ./deploy.sh marxdown development about
+    SITE_SEARCH_ENABLED=0 ./deploy.sh marxdown development about
   on:
     branch: development
 - provider: script
   script:
     SITE_HUMAN_NAME="arXiv Labs" SITE_HUMAN_SHORT_NAME=Labs ./make_and_push_image.sh labs &&
-    ./deploy.sh marxdown development labs
+    SITE_SEARCH_ENABLED=0 ./deploy.sh marxdown development labs
   on:
     branch: development

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+FROM arxiv/base-with-git:0.14.3
+
+WORKDIR /opt/arxiv/
+
+RUN pip install -U pip pipenv
+RUN pipenv install uwsgi arxiv-marxdown
+ENV LC_ALL en_US.utf-8
+ENV LANG en_US.utf-8
+
+ARG NOCACHE=1
+
+ENV PATH "/opt/arxiv:${PATH}"
+
+EXPOSE 8000
+ENV LOGLEVEL 40
+
+ARG SITE_NAME
+ARG SITE_HUMAN_NAME
+ARG SITE_HUMAN_SHORT_NAME
+ARG SITE_SEARCH_ENABLED
+ARG VERSION
+ARG SOURCE
+ARG SOURCE_DIR
+ARG BUILD_TIME
+
+ENV SITE_NAME=$SITE_NAME
+ENV SITE_HUMAN_NAME=$SITE_HUMAN_NAME
+ENV SITE_HUMAN_SHORT_NAME=$SITE_HUMAN_SHORT_NAME
+ENV SITE_SEARCH_ENABLED=$SITE_SEARCH_ENABLED
+ENV VERSION=$VERSION
+ENV SOURCE=$SOURCE
+ENV SOURCE_DIR=$SOURCE_DIR
+ENV SOURCE_PATH=/opt/arxiv/source/$SOURCE_DIR
+ENV BUILD_TIME=$BUILD_TIME
+
+ADD ./build /opt/arxiv/source/
+ADD ./build/.git /opt/arxiv/source/.git/
+
+ENV BUILD_PATH /opt/arxiv/build
+RUN ls -la /opt/arxiv/source
+RUN pipenv run python -m arxiv.marxdown.build
+
+ENTRYPOINT ["pipenv", "run", "uwsgi"]
+CMD ["--http-socket", ":8000", \
+     "-M", \
+     "-t 3000", \
+     "--manage-script-name", \
+     "--processes", "8", \
+     "--threads", "1", \
+     "--async", "100", \
+     "--ugreen", \
+     "--mount", "/=arxiv.marxdown.wsgi:application", \
+     "--static-map", "/static=${BUILD_PATH}/static", \
+     "--static-map", "/_docs/static=/opt/arxiv/docs/static", \
+     "--logformat", "%(addr) %(addr) - %(user_id)|%(session_id) [%(rtime)] [%(uagent)] \"%(method) %(uri) %(proto)\" %(status) %(size) %(micros) %(ttfb)"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,12 +43,11 @@ RUN pipenv run python -m arxiv.marxdown.build
 ENTRYPOINT ["pipenv", "run", "uwsgi"]
 CMD ["--http-socket", ":8000", \
      "-M", \
+     "-T", \
      "-t 3000", \
      "--manage-script-name", \
      "--processes", "8", \
-     "--threads", "1", \
-     "--async", "100", \
-     "--ugreen", \
+     "--threads", "4", \
      "--mount", "/=arxiv.marxdown.wsgi:application", \
      "--static-map", "/static=${BUILD_PATH}/static", \
      "--static-map", "/_docs/static=/opt/arxiv/docs/static", \

--- a/Makefile
+++ b/Makefile
@@ -1,43 +1,33 @@
-
-export REPO_ORG=arxiv
-export REPO_NAME=arxiv-docs
-export TARGET_REPO=git@github.com:${REPO_ORG}/${REPO_NAME}.git
-export SOURCE_REF=0.0.0
-export SOURCE_DIR=help
-export SITE_NAME=help
-export SITE_HUMAN_NAME="arXiv Help Pages"
-export IMAGE_NAME=arxiv/help
-export TMP_DIR=/tmp/docs-build
-export PROJECT_NAME=arXiv Static
-export BUILD_TIME=`date`
-export NOCACHE=`date +%s`
-
-
-remote: Makefile
-	./markdown/bin/make_remote.sh && \
-		rm -rf ./markdown/source && mkdir ./markdown/source &&  \
-		cp -R ${TMP_DIR}/${SOURCE_DIR}/* ./markdown/source && \
-		docker build ./markdown/ \
-			--build-arg NOCACHE=${NOCACHE} \
-			--build-arg VERSION=${SOURCE_REF} \
-			--build-arg BUILD_TIME=$(date) \
-			--build-arg SOURCE=${REPO_ORG}/${REPO_NAME} \
-			--build-arg SITE_NAME=${SITE_NAME} \
-			--build-arg SITE_HUMAN_NAME=${SITE_HUMAN_NAME} \
-		 	-f ./markdown/Dockerfile -t ${IMAGE_NAME}:${SOURCE_REF} && \
-		rm -rf ./markdown/source
+REPO_ORG?=arxiv
+REPO_NAME?=arxiv-docs
+REPO_PATH?=.
+TARGET_REPO?=git@github.com:${REPO_ORG}/${REPO_NAME}.git
+SOURCE_REF?=0.0.0
+SOURCE_DIR?=help
+SITE_NAME?=help
+SITE_HUMAN_NAME?="arXiv Help Pages"
+SITE_HUMAN_SHORT_NAME?=Help
+SITE_SEARCH_ENABLED?=1
+IMAGE_NAME?=arxiv/help
+BUILD_TIME?=$(date)
+NOCACHE?=`date +%s`
 
 local: Makefile
-	echo "Build locally at "${BUILD_TIME} && \
-	rm -rf ./markdown/source && mkdir ./markdown/source &&  \
-	cp -R ${SOURCE_DIR}/* ./markdown/source && \
-	ls -la ./markdown/source && \
-	docker build ./markdown/ \
+	echo "Build locally at "${BUILD_TIME}
+	rm -rf ./build
+	mkdir ./build
+	mkdir ./build/${SOURCE_DIR}
+	cp -R ${REPO_PATH}/${SOURCE_DIR}/* ./build/${SOURCE_DIR}/
+	cp -R ${REPO_PATH}/.git ./build
+	docker build . \
 		--build-arg NOCACHE=${NOCACHE} \
 		--build-arg VERSION=${SOURCE_REF} \
 		--build-arg BUILD_TIME="${BUILD_TIME}" \
 		--build-arg SOURCE=${REPO_ORG}/${REPO_NAME} \
+		--build-arg SOURCE_DIR=${SOURCE_DIR} \
+		--build-arg SITE_SEARCH_ENABLED=${SITE_SEARCH_ENABLED} \
 		--build-arg SITE_NAME=${SITE_NAME} \
-		--build-arg SITE_HUMAN_NAME=${SITE_HUMAN_NAME} \
-		-f ./markdown/Dockerfile -t ${IMAGE_NAME}:${SOURCE_REF} && \
-	rm -rf ./markdown/source
+		--build-arg SITE_HUMAN_NAME='${SITE_HUMAN_NAME}' \
+		--build-arg SITE_HUMAN_SHORT_NAME=${SITE_HUMAN_SHORT_NAME} \
+		-f ./Dockerfile -t ${IMAGE_NAME}:${SOURCE_REF}
+	rm -rf ./build

--- a/README.md
+++ b/README.md
@@ -69,39 +69,6 @@ template: mysite/custom.html
 
 ## Building a site
 
-### Building a local site with Flask
-
-To build a site from markdown sources, you will need to specify the ``SITE_NAME``, ``SOURCE_PATH``, and ``BUILD_PATH`` (see [configuration](#configuration), below).
-
-The application for building and serving the site is located in ``markdown/`` (a submodule, pointing at https://github.com/arxiv/arxiv-markdown).
-
-If you're using this for the first time, you may need to do:
-
-```bash
-git submodule update --init
-cd markdown
-pipenv install
-```
-
-Then you can build with (from inside `./markdown`):
-
-```bash
-SITE_NAME=mysite SOURCE_PATH=/path/to/mysite BUILD_PATH=/tmp/mysite pipenv run python build.py
-```
-
-You can serve the site with Flask, using:
-
-```bash
-SITE_NAME=mysite SOURCE_PATH=/path/to/mysite BUILD_PATH=/tmp/mysite  FLASK_APP=app.py pipenv run flask run
-```
-
-Note that if you're trying to serve stuff in this repo, you can use a relative
-path like:
-
-```bash
-SOURCE_PATH=../help
-```
-
 ### Building a local site with Docker
 
 You can use the ``Makefile`` in the root of this repo to build a site.
@@ -114,7 +81,9 @@ To build a site from a local directory, you can do something like:
 ```bash
 make local SOURCE_REF=0.1 SOURCE_DIR=/path/to/my/site SITE_NAME=mysite IMAGE_NAME=arxiv/mysite
 ```
-Note that as each folder in the root directory is served separately SOURCE_DIR needs to include the specific folder (ex 'help', 'about').
+
+Note that as each folder in the root directory is served separately SOURCE_DIR
+needs to include the specific folder (ex 'help', 'about').
 
 You should see lots of things happening, and maybe this will take a few minutes
 if you have a big site. At the end, you should see something like:
@@ -134,26 +103,6 @@ docker run -it -p 8000:8000 arxiv/mysite:0.1
 
 In your browser, go to http://localhost:8000/mysite (or whatever
 page you want). Note http://localhost:8000 is what works in Ubuntu.
-
-### Building a remote site
-
-You can also build a site that is on GitHub, using a specific [tag](https://help.github.com/articles/working-with-tags/).
-
-You will need to pick a place on your computer to do the building. Preferably
-something in ``/tmp``.
-
-```bash
-make remote SOURCE_REF=0.1 IMAGE_NAME=arxiv/mysite REPO_ORG=arxiv REPO_NAME=arxiv-docs SOURCE_DIR=help
-```
-
-- ``SOURCE_REF=0.1`` This is the tag that you're building.
-- ``IMAGE_NAME=arxiv/mysite`` The name of the image that you're building.
-- ``REPO_ORG=arxiv`` The organization that owns the repo.
-- ``REPO_NAME=arxiv-docs`` The name of the repo.
-- ``SOURCE_DIR=help`` The directory in the repo that contains the site.
-
-This should work just like the local build, except that it might take a bit
-longer because it has to download things.
 
 ### Configuration
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -111,7 +111,7 @@ helm get $HELM_RELEASE --tiller-namespace $ENVIRONMENT 2> /dev/null \
         --set=namespace=$ENVIRONMENT \
         --set=sub_path="/"$SITE_NAME \
         --tiller-namespace $ENVIRONMENT \
-        --namespace $ENVIRONMENT > 2> /dev/null
+        --namespace $ENVIRONMENT 2> /dev/null
 DEPLOY_EXIT=$?
 
 # Send the result back to GitHub.

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+
+# Deploy builds to Kubernetes!
+#
+# This script can be used to deploy builds to Kubernetes using Helm.
+#
+# Params:
+# - chart name (not including repository name)
+# - namespace (used to select other env vars, see below)
+#
+# Pre-requisites:
+# - Must have already provisioned an SA for Tiller, and initialized the Tiller
+#   service in the target namespace.
+# - Must have already provisioned an SA for Travis in the target namespace.
+#   The following env vars should be set, e.g. in the Travis-CI interface:
+#   - USER_SA_{namespace} = the service account name
+#   - USER_TOKEN_{namespace} = base64-encoded bearer token for the Travis SA.
+# - In addition, the following env vars must be set to configure access to
+#   the Kubernetes API server:
+#   - CLUSTER_ENDPOINT = URI of the K8s API server
+#   - CA_CERT = base64 encoded root CA of the K8s cluster
+#   - CLUSTER_NAME = the name of the cluster
+# - The following env vars must be set for Helm to work:
+#   - HELM_REPOSITORY = the location of the arXiv helm repository,
+#     e.g. s3://...
+# - DEPLOYMENT_DOMAIN_{namespace}
+
+CHART_NAME=$1
+ENVIRONMENT=$2
+SITE_NAME=$3
+TOKEN_NAME=USER_TOKEN_$(echo $ENVIRONMENT | awk '{print toupper($0)}')
+SA_NAME=USER_SA_$(echo $ENVIRONMENT | awk '{print toupper($0)}')
+DEPLOYMENT_HOSTNAME_VAR=DEPLOYMENT_DOMAIN_$(echo $ENVIRONMENT | awk '{print toupper($0)}')
+USER_TOKEN=${!TOKEN_NAME}
+USER_SA=${!SA_NAME}
+HELM_RELEASE=${CHART_NAME}-${SITE_NAME}-${ENVIRONMENT}
+DEPLOYMENT_HOSTNAME=${!DEPLOYMENT_HOSTNAME_VAR}
+
+if [ -z "${TRAVIS_TAG}" ]; then
+    IMAGE_TAG=${TRAVIS_COMMIT}
+else
+    IMAGE_TAG=${TRAVIS_TAG}
+fi
+IMAGE_NAME=arxiv/${SITE_NAME}
+
+if [[ ! $TRAVIS_BRANCH =~ "^develop|master$" ]]; then
+    SLUG_BRANCHNAME=$(echo $TRAVIS_BRANCH | iconv -t ascii//TRANSLIT | sed -E 's/[~\^]+//g' | sed -E 's/[^a-zA-Z0-9]+/-/g' | sed -E 's/^-+\|-+$//g' | sed -E 's/^-+//g' | sed -E 's/-+$//g' | tr A-Z a-z);
+    HELM_RELEASE=$CHART_NAME"-"$SITE_NAME"-"$SLUG_BRANCHNAME
+    DEPLOYMENT_HOSTNAME=$CHART_NAME"-"$SLUG_BRANCHNAME"."$DEPLOYMENT_HOSTNAME
+
+else
+    DEPLOYMENT_HOSTNAME=$CHART_NAME"."$DEPLOYMENT_HOSTNAME
+fi
+
+echo "Deploying ${CHART_NAME} in ${ENVIRONMENT}"
+
+# Install kubectl & Helm
+curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.9.2/bin/linux/amd64/kubectl
+chmod +x ./kubectl
+sudo mv ./kubectl /usr/local/bin/kubectl
+echo "Intalled kubectl"
+
+curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
+chmod 700 get_helm.sh
+sudo ./get_helm.sh -v v2.8.0 || echo "Helm already installed"
+echo "Intalled Helm"
+
+# Configure Kubernetes & Helm
+echo $CA_CERT | base64 --decode > ${HOME}/ca.crt
+
+kubectl config set-cluster $CLUSTER_NAME --embed-certs=true --server=$CLUSTER_ENDPOINT --certificate-authority=${HOME}/ca.crt
+kubectl config set-credentials $USER_SA --token=$(echo $USER_TOKEN | base64 --decode)
+kubectl config set-context travis --cluster=$CLUSTER_NAME --user=$USER_SA --namespace=$ENVIRONMENT
+kubectl config use-context travis
+kubectl config current-context
+echo "Configured kubectl"
+
+helm init --client-only --tiller-namespace $ENVIRONMENT
+echo "Set up helm client"
+
+# Add S3 repo. Requires AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY to be set
+# in the environment.
+helm plugin install https://github.com/hypnoglow/helm-s3.git || echo "Helm S3 already installed"
+helm repo add arxiv $HELM_REPOSITORY
+helm repo update
+echo "Updated Helm repo"
+
+# Deploy to Kubernetes.
+helm get $HELM_RELEASE --tiller-namespace $ENVIRONMENT 2> /dev/null \
+    && helm upgrade $HELM_RELEASE arxiv/$CHART_NAME \
+        --set=imageName=$IMAGE_NAME \
+        --set=imageTag=$TRAVIS_COMMIT \
+        --set=siteName=$SITE_NAME \
+        --set=deploymentName=$HELM_RELEASE \
+        --set=serviceName=$HELM_RELEASE \
+        --set=ingressName=$HELM_RELEASE \
+        --set=host=$DEPLOYMENT_HOSTNAME \
+        --set=namespace=$ENVIRONMENT \
+        --set=sub_path="/"$SITE_NAME \
+        --tiller-namespace $ENVIRONMENT \
+        --namespace $ENVIRONMENT 2> /dev/null \
+    || helm install arxiv/$CHART_NAME \
+        --name=$HELM_RELEASE \
+        --set=imageName=$IMAGE_NAME \
+        --set=imageTag=$TRAVIS_COMMIT \
+        --set=siteName=$SITE_NAME \
+        --set=deploymentName=$HELM_RELEASE \
+        --set=serviceName=$HELM_RELEASE \
+        --set=ingressName=$HELM_RELEASE \
+        --set=host=$DEPLOYMENT_HOSTNAME \
+        --set=namespace=$ENVIRONMENT \
+        --set=sub_path="/"$SITE_NAME \
+        --tiller-namespace $ENVIRONMENT \
+        --namespace $ENVIRONMENT > 2> /dev/null
+DEPLOY_EXIT=$?
+
+# Send the result back to GitHub.
+if [ $DEPLOY_EXIT -ne 0 ]; then
+    DEPLOY_STATE="failure"
+    echo "Deployment failed"
+else
+    DEPLOY_STATE="success"
+    echo "Deployed!"
+fi
+
+if [ "$TRAVIS_PULL_REQUEST_SHA" = "" ];  then SHA=$TRAVIS_COMMIT; else SHA=$TRAVIS_PULL_REQUEST_SHA; fi
+curl -u $USERNAME:$GITHUB_TOKEN \
+    -d '{"state": "'$DEPLOY_STATE'", "target_url": "https://'$DEPLOYMENT_HOSTNAME'/'$SITE_NAME'", "description": "Deploy '$DEPLOY_STATE' for '$DEPLOYMENT_HOSTNAME'/'$SITE_NAME'", "context": "deploy/'$SITE_NAME'"}' \
+    -XPOST https://api.github.com/repos/$TRAVIS_REPO_SLUG/statuses/$SHA > /dev/null 2>&1 && \
+    echo "Sent result to GitHub"
+
+function cleanup {
+    printf "Cleaning up...\n"
+    rm -vf "${HOME}/ca.crt"
+    printf "Cleaning done."
+}
+
+trap cleanup EXIT

--- a/deploy.sh
+++ b/deploy.sh
@@ -36,6 +36,8 @@ USER_SA=${!SA_NAME}
 HELM_RELEASE=${CHART_NAME}-${SITE_NAME}-${ENVIRONMENT}
 DEPLOYMENT_HOSTNAME=${!DEPLOYMENT_HOSTNAME_VAR}
 
+if [ -z "$SITE_SEARCH_ENABLED" ]; then SITE_SEARCH_ENABLED="1"; fi
+
 if [ -z "${TRAVIS_TAG}" ]; then
     IMAGE_TAG=${TRAVIS_COMMIT}
 else
@@ -47,7 +49,6 @@ if [[ ! $TRAVIS_BRANCH =~ "^develop|master$" ]]; then
     SLUG_BRANCHNAME=$(echo $TRAVIS_BRANCH | iconv -t ascii//TRANSLIT | sed -E 's/[~\^]+//g' | sed -E 's/[^a-zA-Z0-9]+/-/g' | sed -E 's/^-+\|-+$//g' | sed -E 's/^-+//g' | sed -E 's/-+$//g' | tr A-Z a-z);
     HELM_RELEASE=$CHART_NAME"-"$SITE_NAME"-"$SLUG_BRANCHNAME
     DEPLOYMENT_HOSTNAME=$CHART_NAME"-"$SLUG_BRANCHNAME"."$DEPLOYMENT_HOSTNAME
-
 else
     DEPLOYMENT_HOSTNAME=$CHART_NAME"."$DEPLOYMENT_HOSTNAME
 fi
@@ -97,6 +98,7 @@ helm get $HELM_RELEASE --tiller-namespace $ENVIRONMENT 2> /dev/null \
         --set=host=$DEPLOYMENT_HOSTNAME \
         --set=namespace=$ENVIRONMENT \
         --set=sub_path="/"$SITE_NAME \
+        --set=siteSearchEnabled=$SITE_SEARCH_ENABLED \
         --tiller-namespace $ENVIRONMENT \
         --namespace $ENVIRONMENT 2> /dev/null \
     || helm install arxiv/$CHART_NAME \
@@ -110,6 +112,7 @@ helm get $HELM_RELEASE --tiller-namespace $ENVIRONMENT 2> /dev/null \
         --set=host=$DEPLOYMENT_HOSTNAME \
         --set=namespace=$ENVIRONMENT \
         --set=sub_path="/"$SITE_NAME \
+        --set=siteSearchEnabled=$SITE_SEARCH_ENABLED \
         --tiller-namespace $ENVIRONMENT \
         --namespace $ENVIRONMENT 2> /dev/null
 DEPLOY_EXIT=$?

--- a/help/faq/citelinks.md
+++ b/help/faq/citelinks.md
@@ -1,3 +1,7 @@
+---
+title: Why do my citations appear in long form
+---
+
 # Why do my citations appear in long form [1,2,3,4] instead of short form [1-4]?
 
 Some latex packages such as the `cite` package normally show citations

--- a/make_and_push_image.sh
+++ b/make_and_push_image.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -o pipefail
+set -o errexit
+set -o nounset
+
+# Used to deploy
+
+export SOURCE_DIR=$1
+export LOGLEVEL=40
+export SITE_NAME=$SOURCE_DIR
+export IMAGE_NAME=arxiv/${SOURCE_DIR}
+if [ -z "${TRAVIS_TAG}" ]; then
+    export SOURCE_REF=${TRAVIS_COMMIT}
+else
+    export SOURCE_REF=${TRAVIS_TAG}
+fi
+
+git fetch --unshallow || echo "Repository is already complete"
+docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
+make local
+docker push ${IMAGE_NAME}:${SOURCE_REF}


### PR DESCRIPTION
This adds continuous deployment for commits to this repository. Commits trigger builds on Travis-CI.org (e.g. see https://travis-ci.org/arXiv/arxiv-docs/branches). Here's what happens right now on Travis:

- Each top-level site in this repo is built as a Docker image, ``arxiv/[site name]``
- The Docker image gets pushed to Docker Hub. For example: https://cloud.docker.com/u/arxiv/repository/docker/arxiv/about
- Each top-level site gets deployed to the development (feature + ``develop`` branches) or staging (``master`` branch) site. 
- The result of the deployment gets reported back to GitHub. 

On commit views (e.g. see https://github.com/arXiv/arxiv-docs/commits/task/ARXIVNG-1795) and on the pull request view (e.g. this PR) you will see green checkmarks or red Xes depending on whether the build succeeded or failed. 

![image](https://user-images.githubusercontent.com/3451594/53097816-5424bd00-34f0-11e9-94d7-aaa86fc33580.png)

If you click on the green check mark, you should see something like this:

![image](https://user-images.githubusercontent.com/3451594/53097853-643c9c80-34f0-11e9-9383-790b2d29fb47.png)

Note that there should be a deployment result for each top-level site. If you click on "details" next to that status, it should take you to the deployment.  