### PR TITLE
ARXIVNG-2400 added developers page to /about

### DIFF
--- a/about/index.md
+++ b/about/index.md
@@ -33,4 +33,4 @@ arXiv® is an e-print service in the fields of physics, mathematics, computer sc
 - [Scientific Advisory Board](/help/scientific_ad_board)
 - [Member Advisory Board](https://confluence.cornell.edu/display/arxivpub/Member+Advisory+Board)
 - [Volunteer Moderators](/moderators)
-- [Developers](developers)
+- [Volunteer Developers](people/developers)

--- a/about/index.md
+++ b/about/index.md
@@ -33,4 +33,4 @@ arXiv® is an e-print service in the fields of physics, mathematics, computer sc
 - [Scientific Advisory Board](/help/scientific_ad_board)
 - [Member Advisory Board](https://confluence.cornell.edu/display/arxivpub/Member+Advisory+Board)
 - [Volunteer Moderators](/moderators)
-
+- [Developers](developers)

--- a/about/people/developers.md
+++ b/about/people/developers.md
@@ -11,7 +11,8 @@ technology, nor the evolving needs of 21st century science, without the help of
 dedicated arXiv users who contribute to the open source software that powers
 the arXiv platform.
 
-We are grateful to the following external developers for their contributions to the arXiv codebase:
+We are grateful to the following external developers for their contributions to
+the arXiv codebase:
 
 - Takeo Imai ([bonotake](https://github.com/bonotake))
 - Warren Price ([warpri81](https://github.com/warpri81))

--- a/about/people/developers.md
+++ b/about/people/developers.md
@@ -1,0 +1,27 @@
+---
+title: 'Volunteer Developers'
+---
+
+# Volunteer Developers
+
+The technical infrastructure and software behind arXiv.org is operated and
+maintained by a core team of dedicated IT staff at Cornell. However, it would
+not be possible to keep pace with the ever-changing landscape of internet
+technology, nor the evolving needs of 21st century science, without the help of
+dedicated arXiv users who contribute to the open source software that powers
+the arXiv platform.
+
+We are grateful to the following external developers for their contributions to the arXiv codebase:
+
+- Takeo Imai ([bonotake](https://github.com/bonotake))
+- Warren Price ([warpri81](https://github.com/warpri81))
+- John Cook ([johncookds](https://github.com/johncookds))
+- Darien Yeung ([Yeungdb](https://github.com/Yeungdb))
+- Sawood Alam ([ibnesayeed](https://github.com/ibnesayeed))
+- Adhitya Mohan ([poad42](https://github.com/poad42))
+- Tanvi Anand ([tanvi15](https://github.com/tanvi15))
+
+Please see our [guidelines for
+contributors](https://github.com/arXiv/.github/blob/master/CONTRIBUTING.md), or
+contact Erick Peirson (brp53@cornell.edu), for more information about
+contributing to arXiv software development.

--- a/about/people/developers.md
+++ b/about/people/developers.md
@@ -11,7 +11,7 @@ technology, nor the evolving needs of 21st century science, without the help of
 dedicated arXiv users who contribute to the open source software that powers
 the arXiv platform.
 
-We are grateful to the following external developers for their contributions to
+We are grateful to the following volunteer developers for their contributions to
 the arXiv codebase:
 
 - Takeo Imai ([bonotake](https://github.com/bonotake))

--- a/about/people/index.md
+++ b/about/people/index.md
@@ -10,6 +10,7 @@ For more information about who is arXiv please see:
 
 - [Staff Leadership Team](leadership_team)
 - [Moderators](/moderators/)
+- [Developers](developers)
 - [Scientific Advisory Board and Subject Advisory Committees](/help/scientific_ad_board)
 - [Member Advisory Board](https://confluence.cornell.edu/display/arxivpub/Member+Advisory+Board)
 - [Org Chart](https://confluence.cornell.edu/download/attachments/340886427/arXiv-org-January2019.pdf?version=1&modificationDate=1546891957674&api=v2)

--- a/about/people/index.md
+++ b/about/people/index.md
@@ -10,7 +10,7 @@ For more information about who is arXiv please see:
 
 - [Staff Leadership Team](leadership_team)
 - [Moderators](/moderators/)
-- [Developers](developers)
+- [Volunteer Developers](developers)
 - [Scientific Advisory Board and Subject Advisory Committees](/help/scientific_ad_board)
 - [Member Advisory Board](https://confluence.cornell.edu/display/arxivpub/Member+Advisory+Board)
 - [Org Chart](https://confluence.cornell.edu/download/attachments/340886427/arXiv-org-January2019.pdf?version=1&modificationDate=1546891957674&api=v2)


### PR DESCRIPTION
Adds a page at ``/about/people/developers`` and attendant links.

![image](https://user-images.githubusercontent.com/3451594/60909735-01ecfa00-a24d-11e9-98e6-ff3941e0129c.png)
