### PR TITLE
initial migration to md

### DIFF
--- a/new/withdrawals.aug.07.md
+++ b/new/withdrawals.aug.07.md
@@ -5,61 +5,33 @@
 
 The 14 authors, and the number of withdrawn articles co-authored by each, are as follows:
 
-40
+40  [M. Salti](http://arxiv.org/find/gr-qc/1/au:+salti_m/0/1/0/all/0/1) (Grad Student, [METU](HTTP://WWW.METU.EDU.TR/), Ankara)
 
-  [M. Salti](http://arxiv.org/find/gr-qc/1/au:+salti_m/0/1/0/all/0/1) (Grad Student, [METU](HTTP://WWW.METU.EDU.TR/), Ankara)
+29  [O. Aydogdu](http://arxiv.org/find/gr-qc/1/au:+aydogdu_o/0/1/0/all/0/1) (Grad Student, [METU](HTTP://WWW.METU.EDU.TR/), Ankara)
 
-29
+15  [S. Aygun](http://arxiv.org/find/gr-qc/1/au:+aygun_s/0/1/0/all/0/1) (Grad Student, [18 Mart Univ](http://www.comu.edu.tr/english/), Canakkale)
 
-  [O. Aydogdu](http://arxiv.org/find/gr-qc/1/au:+aydogdu_o/0/1/0/all/0/1) (Grad Student, [METU](HTTP://WWW.METU.EDU.TR/), Ankara)
+14  [M. Korunur](http://arxiv.org/find/gr-qc/1/au:+korunur_m/0/1/0/all/0/1) (Grad Student, [Dicle Univ](http://www.dicle.edu.tr/webing/engindex.html), Diyarbakir)
 
-15
+13  [A. Havare](http://arxiv.org/find/gr-qc/1/au:+havare_a/0/1/0/all/0/1) (Assoc Prof., [Mersin Univ](http://www.mersin.edu.tr/index.php?module=2), Icel)
 
-  [S. Aygun](http://arxiv.org/find/gr-qc/1/au:+aygun_s/0/1/0/all/0/1) (Grad Student, [18 Mart Univ](http://www.comu.edu.tr/english/), Canakkale)
+13  [I. Tarhan](http://arxiv.org/find/gr-qc/1/au:+tarhan_i/0/1/0/all/0/1) (Assoc. Prof., [18 Mart Univ](http://www.comu.edu.tr/english/), Canakkale)
 
-14
+10  [M. Aygun](http://arxiv.org/find/gr-qc/1/au:+aygun_m/0/1/0/all/0/1) (Grad Student, [18 Mart Univ](http://www.comu.edu.tr/english/), Canakkale)
 
-  [M. Korunur](http://arxiv.org/find/gr-qc/1/au:+korunur_m/0/1/0/all/0/1) (Grad Student, [Dicle Univ](http://www.dicle.edu.tr/webing/engindex.html), Diyarbakir)
+7  [H. Baysal](http://arxiv.org/find/gr-qc/1/au:+baysal_h/0/1/0/all/0/1) (Assoc Prof., [18 Mart Univ](http://www.comu.edu.tr/english/), Canakkale)
 
-13
+5  [I. Acikgoz](http://arxiv.org/find/gr-qc/1/au:+acikgoz_i/0/1/0/all/0/1) (Professor, [Dicle Univ](http://www.dicle.edu.tr/webing/engindex.html), Diyarbakir)
 
-  [A. Havare](http://arxiv.org/find/gr-qc/1/au:+havare_a/0/1/0/all/0/1) (Assoc Prof., [Mersin Univ](http://www.mersin.edu.tr/index.php?module=2), Icel)
+4  [I. Yilmaz](http://arxiv.org/find/astro-ph,gr-qc/1/au:+yilmaz_i/0/1/0/all/0/1) (Professor, Dean, [18 Mart Univ](http://www.comu.edu.tr/english/), Canakkale)
 
-13
+3  [F. Binbay](http://arxiv.org/find/gr-qc/1/au:+binbay_f/0/1/0/all/0/1) (Assistant Prof., [Dicle Univ](http://www.dicle.edu.tr/webing/engindex.html), Diyarbakir)
 
-  [I. Tarhan](http://arxiv.org/find/gr-qc/1/au:+tarhan_i/0/1/0/all/0/1) (Assoc. Prof., [18 Mart Univ](http://www.comu.edu.tr/english/), Canakkale)
+3  [N. Pirinccioglu](http://arxiv.org/find/gr-qc/1/au:+pirinccioglu_n/0/1/0/all/0/1) (Grad Student, [Dicle Univ](http://www.dicle.edu.tr/webing/engindex.html), Diyarbakir)
 
-10
+3  [T. Yetkin](http://arxiv.org/find/gr-qc/1/au:+yetkin_t/0/1/0/all/0/1) (Instructor with PhD, [Mersin Univ](http://www.mersin.edu.tr/index.php?module=2), Icel)
 
-  [M. Aygun](http://arxiv.org/find/gr-qc/1/au:+aygun_m/0/1/0/all/0/1) (Grad Student, [18 Mart Univ](http://www.comu.edu.tr/english/), Canakkale)
-
-7
-
-  [H. Baysal](http://arxiv.org/find/gr-qc/1/au:+baysal_h/0/1/0/all/0/1) (Assoc Prof., [18 Mart Univ](http://www.comu.edu.tr/english/), Canakkale)
-
-5
-
-  [I. Acikgoz](http://arxiv.org/find/gr-qc/1/au:+acikgoz_i/0/1/0/all/0/1) (Professor, [Dicle Univ](http://www.dicle.edu.tr/webing/engindex.html), Diyarbakir)
-
-4
-
-  [I. Yilmaz](http://arxiv.org/find/astro-ph,gr-qc/1/au:+yilmaz_i/0/1/0/all/0/1) (Professor, Dean, [18 Mart Univ](http://www.comu.edu.tr/english/), Canakkale)
-
-3
-
-  [F. Binbay](http://arxiv.org/find/gr-qc/1/au:+binbay_f/0/1/0/all/0/1) (Assistant Prof., [Dicle Univ](http://www.dicle.edu.tr/webing/engindex.html), Diyarbakir)
-
-3
-
-  [N. Pirinccioglu](http://arxiv.org/find/gr-qc/1/au:+pirinccioglu_n/0/1/0/all/0/1) (Grad Student, [Dicle Univ](http://www.dicle.edu.tr/webing/engindex.html), Diyarbakir)
-
-3
-
-  [T. Yetkin](http://arxiv.org/find/gr-qc/1/au:+yetkin_t/0/1/0/all/0/1) (Instructor with PhD, [Mersin Univ](http://www.mersin.edu.tr/index.php?module=2), Icel)
-
-1
-
-  [C. Aktas](http://arxiv.org/find/gr-qc/1/au:+aktas_c/0/1/0/all/0/1) (Grad Student, Math Dept, [18 Mart Univ](http://www.comu.edu.tr/english/), Canakkale)
+1  [C. Aktas](http://arxiv.org/find/gr-qc/1/au:+aktas_c/0/1/0/all/0/1) (Grad Student, Math Dept, [18 Mart Univ](http://www.comu.edu.tr/english/), Canakkale)
 
 **Note 1:** The name [K. Sogut](http://arxiv.org/find/hep-th/1/au:+sogut_k/0/1/0/all/0/1) (Instructor with PhD, Mersin Univ, Icel), who has co-authored with others on the above list, was erroneously included in an earlier version of this list due to an arXiv administrative error. There are no known problems with arXiv.org articles co-authored by K. Sogut.
 
@@ -70,67 +42,131 @@ The 14 authors, and the number of withdrawn articles co-authored by each, are as
 The 65 withdrawn articles are listed below (the author submissions remain available as earlier versions):  
   
 [gr-qc/0110023](/abs/gr-qc/0110023)
+
 [gr-qc/0207026](/abs/gr-qc/0207026)
+
 [gr-qc/0502031](/abs/gr-qc/0502031)
+
 [gr-qc/0502032](/abs/gr-qc/0502032)
+
 [gr-qc/0502042](/abs/gr-qc/0502042)
+
 [gr-qc/0502043](/abs/gr-qc/0502043)
+
 [gr-qc/0502058](/abs/gr-qc/0502058)
+
 [gr-qc/0502059](/abs/gr-qc/0502059)
+
 [gr-qc/0502060](/abs/gr-qc/0502060)
+
 [gr-qc/0502061](/abs/gr-qc/0502061)
+
 [gr-qc/0505078](/abs/gr-qc/0505078)
+
 [gr-qc/0505079](/abs/gr-qc/0505079)
+
 [gr-qc/0506061](/abs/gr-qc/0506061)
+
 [gr-qc/0506062](/abs/gr-qc/0506062)
+
 [gr-qc/0506135](/abs/gr-qc/0506135)
+
 [gr-qc/0508018](/abs/gr-qc/0508018)
+
 [gr-qc/0509022](/abs/gr-qc/0509022)
+
 [gr-qc/0509023](/abs/gr-qc/0509023)
+
 [gr-qc/0509047](/abs/gr-qc/0509047)
+
 [gr-qc/0509061](/abs/gr-qc/0509061)
+
 [gr-qc/0510037](/abs/gr-qc/0510037)
+
 [gr-qc/0510038](/abs/gr-qc/0510038)
+
 [gr-qc/0510123](/abs/gr-qc/0510123)
+
 [gr-qc/0511030](/abs/gr-qc/0511030)
+
 [gr-qc/0511095](/abs/gr-qc/0511095)
+
 [gr-qc/0512080](/abs/gr-qc/0512080)
+
 [gr-qc/0601070](/abs/gr-qc/0601070)
+
 [gr-qc/0601133](/abs/gr-qc/0601133)
+
 [gr-qc/0601141](/abs/gr-qc/0601141)
+
 [gr-qc/0602012](/abs/gr-qc/0602012)
+
 [gr-qc/0602070](/abs/gr-qc/0602070)
+
 [gr-qc/0603027](/abs/gr-qc/0603027)
+
 [gr-qc/0603044](/abs/gr-qc/0603044)
+
 [gr-qc/0603063](/abs/gr-qc/0603063)
+
 [gr-qc/0603108](/abs/gr-qc/0603108)
+
 [gr-qc/0606022](/abs/gr-qc/0606022)
+
 [gr-qc/0606028](/abs/gr-qc/0606028)
+
 [gr-qc/0606080](/abs/gr-qc/0606080)
+
 [gr-qc/0607011](/abs/gr-qc/0607011)
+
 [gr-qc/0607082](/abs/gr-qc/0607082)
+
 [gr-qc/0607083](/abs/gr-qc/0607083)
+
 [gr-qc/0607089](/abs/gr-qc/0607089)
+
 [gr-qc/0607095](/abs/gr-qc/0607095)
+
 [gr-qc/0607102](/abs/gr-qc/0607102)
+
 [gr-qc/0607103](/abs/gr-qc/0607103)
+
 [gr-qc/0607104](/abs/gr-qc/0607104)
+
 [gr-qc/0607109](/abs/gr-qc/0607109)
+
 [gr-qc/0607110](/abs/gr-qc/0607110)
+
 [gr-qc/0607115](/abs/gr-qc/0607115)
+
 [gr-qc/0607116](/abs/gr-qc/0607116)
+
 [gr-qc/0607117](/abs/gr-qc/0607117)
+
 [gr-qc/0607119](/abs/gr-qc/0607119)
+
 [gr-qc/0607126](/abs/gr-qc/0607126)
+
 [gr-qc/0608014](/abs/gr-qc/0608014)
+
 [gr-qc/0608024](/abs/gr-qc/0608024)
+
 [gr-qc/0608050](/abs/gr-qc/0608050)
+
 [gr-qc/0608111](/abs/gr-qc/0608111)
+
 [gr-qc/0609101](/abs/gr-qc/0609101)
+
 [gr-qc/0611014](/abs/gr-qc/0611014)
+
 [gr-qc/0612016](/abs/gr-qc/0612016)
+
 [gr-qc/0702047](/abs/gr-qc/0702047)
+
 [astro-ph/0505018](/abs/astro-ph/0505018)
+
 [0704.0525](/abs/0704.0525)
+
 [0705.2930](/abs/0705.2930)
+
 [0707.1776](/abs/0707.1776)

--- a/new/withdrawals.aug.07.md
+++ b/new/withdrawals.aug.07.md
@@ -1,0 +1,136 @@
+65 admin withdrawals
+====================
+
+65 articles by a group of 14 authors have been withdrawn by the arXiv administration due to excessive reuse of text from articles by other authors. The withdrawn articles were submitted from late 2001 through mid 2007, mainly to gr-qc, and the vast majority (59) were submitted in 2005-2006. (See also this [article](http://arstechnica.com/articles/culture/plagiarism-and-falsified-data-slip-into-the-scientific-literature.ars) for additional details.)
+
+The 14 authors, and the number of withdrawn articles co-authored by each, are as follows:
+
+40
+
+  [M. Salti](http://arxiv.org/find/gr-qc/1/au:+salti_m/0/1/0/all/0/1) (Grad Student, [METU](HTTP://WWW.METU.EDU.TR/), Ankara)
+
+29
+
+  [O. Aydogdu](http://arxiv.org/find/gr-qc/1/au:+aydogdu_o/0/1/0/all/0/1) (Grad Student, [METU](HTTP://WWW.METU.EDU.TR/), Ankara)
+
+15
+
+  [S. Aygun](http://arxiv.org/find/gr-qc/1/au:+aygun_s/0/1/0/all/0/1) (Grad Student, [18 Mart Univ](http://www.comu.edu.tr/english/), Canakkale)
+
+14
+
+  [M. Korunur](http://arxiv.org/find/gr-qc/1/au:+korunur_m/0/1/0/all/0/1) (Grad Student, [Dicle Univ](http://www.dicle.edu.tr/webing/engindex.html), Diyarbakir)
+
+13
+
+  [A. Havare](http://arxiv.org/find/gr-qc/1/au:+havare_a/0/1/0/all/0/1) (Assoc Prof., [Mersin Univ](http://www.mersin.edu.tr/index.php?module=2), Icel)
+
+13
+
+  [I. Tarhan](http://arxiv.org/find/gr-qc/1/au:+tarhan_i/0/1/0/all/0/1) (Assoc. Prof., [18 Mart Univ](http://www.comu.edu.tr/english/), Canakkale)
+
+10
+
+  [M. Aygun](http://arxiv.org/find/gr-qc/1/au:+aygun_m/0/1/0/all/0/1) (Grad Student, [18 Mart Univ](http://www.comu.edu.tr/english/), Canakkale)
+
+7
+
+  [H. Baysal](http://arxiv.org/find/gr-qc/1/au:+baysal_h/0/1/0/all/0/1) (Assoc Prof., [18 Mart Univ](http://www.comu.edu.tr/english/), Canakkale)
+
+5
+
+  [I. Acikgoz](http://arxiv.org/find/gr-qc/1/au:+acikgoz_i/0/1/0/all/0/1) (Professor, [Dicle Univ](http://www.dicle.edu.tr/webing/engindex.html), Diyarbakir)
+
+4
+
+  [I. Yilmaz](http://arxiv.org/find/astro-ph,gr-qc/1/au:+yilmaz_i/0/1/0/all/0/1) (Professor, Dean, [18 Mart Univ](http://www.comu.edu.tr/english/), Canakkale)
+
+3
+
+  [F. Binbay](http://arxiv.org/find/gr-qc/1/au:+binbay_f/0/1/0/all/0/1) (Assistant Prof., [Dicle Univ](http://www.dicle.edu.tr/webing/engindex.html), Diyarbakir)
+
+3
+
+  [N. Pirinccioglu](http://arxiv.org/find/gr-qc/1/au:+pirinccioglu_n/0/1/0/all/0/1) (Grad Student, [Dicle Univ](http://www.dicle.edu.tr/webing/engindex.html), Diyarbakir)
+
+3
+
+  [T. Yetkin](http://arxiv.org/find/gr-qc/1/au:+yetkin_t/0/1/0/all/0/1) (Instructor with PhD, [Mersin Univ](http://www.mersin.edu.tr/index.php?module=2), Icel)
+
+1
+
+  [C. Aktas](http://arxiv.org/find/gr-qc/1/au:+aktas_c/0/1/0/all/0/1) (Grad Student, Math Dept, [18 Mart Univ](http://www.comu.edu.tr/english/), Canakkale)
+
+**Note 1:** The name [K. Sogut](http://arxiv.org/find/hep-th/1/au:+sogut_k/0/1/0/all/0/1) (Instructor with PhD, Mersin Univ, Icel), who has co-authored with others on the above list, was erroneously included in an earlier version of this list due to an arXiv administrative error. There are no known problems with arXiv.org articles co-authored by K. Sogut.
+
+**Note 2:** The name [T. Yetkin](http://arxiv.org/find/gr-qc/1/au:+yetkin_t/0/1/0/all/0/1) appears only in conjunction with senior co-authors who have a more systematically problematic record.
+
+  
+
+The 65 withdrawn articles are listed below (the author submissions remain available as earlier versions):  
+  
+[gr-qc/0110023](/abs/gr-qc/0110023)
+[gr-qc/0207026](/abs/gr-qc/0207026)
+[gr-qc/0502031](/abs/gr-qc/0502031)
+[gr-qc/0502032](/abs/gr-qc/0502032)
+[gr-qc/0502042](/abs/gr-qc/0502042)
+[gr-qc/0502043](/abs/gr-qc/0502043)
+[gr-qc/0502058](/abs/gr-qc/0502058)
+[gr-qc/0502059](/abs/gr-qc/0502059)
+[gr-qc/0502060](/abs/gr-qc/0502060)
+[gr-qc/0502061](/abs/gr-qc/0502061)
+[gr-qc/0505078](/abs/gr-qc/0505078)
+[gr-qc/0505079](/abs/gr-qc/0505079)
+[gr-qc/0506061](/abs/gr-qc/0506061)
+[gr-qc/0506062](/abs/gr-qc/0506062)
+[gr-qc/0506135](/abs/gr-qc/0506135)
+[gr-qc/0508018](/abs/gr-qc/0508018)
+[gr-qc/0509022](/abs/gr-qc/0509022)
+[gr-qc/0509023](/abs/gr-qc/0509023)
+[gr-qc/0509047](/abs/gr-qc/0509047)
+[gr-qc/0509061](/abs/gr-qc/0509061)
+[gr-qc/0510037](/abs/gr-qc/0510037)
+[gr-qc/0510038](/abs/gr-qc/0510038)
+[gr-qc/0510123](/abs/gr-qc/0510123)
+[gr-qc/0511030](/abs/gr-qc/0511030)
+[gr-qc/0511095](/abs/gr-qc/0511095)
+[gr-qc/0512080](/abs/gr-qc/0512080)
+[gr-qc/0601070](/abs/gr-qc/0601070)
+[gr-qc/0601133](/abs/gr-qc/0601133)
+[gr-qc/0601141](/abs/gr-qc/0601141)
+[gr-qc/0602012](/abs/gr-qc/0602012)
+[gr-qc/0602070](/abs/gr-qc/0602070)
+[gr-qc/0603027](/abs/gr-qc/0603027)
+[gr-qc/0603044](/abs/gr-qc/0603044)
+[gr-qc/0603063](/abs/gr-qc/0603063)
+[gr-qc/0603108](/abs/gr-qc/0603108)
+[gr-qc/0606022](/abs/gr-qc/0606022)
+[gr-qc/0606028](/abs/gr-qc/0606028)
+[gr-qc/0606080](/abs/gr-qc/0606080)
+[gr-qc/0607011](/abs/gr-qc/0607011)
+[gr-qc/0607082](/abs/gr-qc/0607082)
+[gr-qc/0607083](/abs/gr-qc/0607083)
+[gr-qc/0607089](/abs/gr-qc/0607089)
+[gr-qc/0607095](/abs/gr-qc/0607095)
+[gr-qc/0607102](/abs/gr-qc/0607102)
+[gr-qc/0607103](/abs/gr-qc/0607103)
+[gr-qc/0607104](/abs/gr-qc/0607104)
+[gr-qc/0607109](/abs/gr-qc/0607109)
+[gr-qc/0607110](/abs/gr-qc/0607110)
+[gr-qc/0607115](/abs/gr-qc/0607115)
+[gr-qc/0607116](/abs/gr-qc/0607116)
+[gr-qc/0607117](/abs/gr-qc/0607117)
+[gr-qc/0607119](/abs/gr-qc/0607119)
+[gr-qc/0607126](/abs/gr-qc/0607126)
+[gr-qc/0608014](/abs/gr-qc/0608014)
+[gr-qc/0608024](/abs/gr-qc/0608024)
+[gr-qc/0608050](/abs/gr-qc/0608050)
+[gr-qc/0608111](/abs/gr-qc/0608111)
+[gr-qc/0609101](/abs/gr-qc/0609101)
+[gr-qc/0611014](/abs/gr-qc/0611014)
+[gr-qc/0612016](/abs/gr-qc/0612016)
+[gr-qc/0702047](/abs/gr-qc/0702047)
+[astro-ph/0505018](/abs/astro-ph/0505018)
+[0704.0525](/abs/0704.0525)
+[0705.2930](/abs/0705.2930)
+[0707.1776](/abs/0707.1776)


### PR DESCRIPTION
This file was originally intentionally skipped as part of the migration to markdown, however there are several front-facing versions of arXiv-ids that link directly to this page, so it should be present. 