### PR TITLE
new mailchimp user testing signup form

### DIFF
--- a/about/user-testing.md
+++ b/about/user-testing.md
@@ -58,14 +58,14 @@ _(note: we recently migrated our list from an old-fashioned listserv to mailchim
 	<label for="mce-RESEARCH">arXiv Research Field * </label>
 	<select name="RESEARCH" class="required" id="mce-RESEARCH">
 	<option value=""></option>
-	<option value="astro-ph">astro-ph</option>
-<option value="math">math</option>
-<option value="CoRR">CoRR</option>
-<option value="q-bio">q-bio</option>
-<option value="q-fin">q-fin</option>
-<option value="stat">stat</option>
-<option value="eess">eess</option>
-<option value="econ">econ</option>
+<option value="Physics">Physics</option>
+<option value="Mathematics">Mathematics</option>
+<option value="Computer Science">Computer Science</option>
+<option value="Quantitative Biology">Quantitative Biology</option>
+<option value="Quantitative Finance">Quantitative Finance</option>
+<option value="Statistics">Statistics</option>
+<option value="Electrical Engineering and Systems Science">Electrical Engineering and Systems Science</option>
+<option value="Economics">Economics</option>
 	</select>
 </div>
 <hr>

--- a/about/user-testing.md
+++ b/about/user-testing.md
@@ -1,0 +1,94 @@
+Join arXiv's User Testing group
+===========================
+
+<style>
+blockquote {
+  border-left: 0;
+  -webkit-box-shadow: 0px 3px 8px 0px rgba(0,0,0,0.12);
+  -moz-box-shadow: 0px 3px 8px 0px rgba(0,0,0,0.12);
+  box-shadow: 0px 3px 8px 0px rgba(0,0,0,0.12);
+  padding:1em;
+  margin-bottom:1.5em;
+}
+@media (min-width: 576px) {
+  blockquote {
+    padding: 2em;
+  }
+}
+</style>
+
+From time to time arXiv sends out surveys, previews to new changes, and other testing opportunities to interested users. If you would like to join our user testing group fill out the form below. User testing is integral to arXiv's development process and we welcome your feedback. We use this list only for user testing communications and never spam or share your information.
+
+_(note: we recently migrated our list from an old-fashioned listserv to mailchimp. The new platform lets us acknowledge important testing criteria like geographic location and use of assistive technology. If you are already part of the user testing list but would like to contribute to a targeted testing group simply fill out the required fields, hit submit, and follow the instructions to update your existing account)_
+
+
+<link href="//cdn-images.mailchimp.com/embedcode/classic-10_7.css" rel="stylesheet" type="text/css">
+<style type="text/css">
+	#mc_embed_signup{background:#fff; clear:left; font-size:14px;}
+  #mc_embed_signup .mc-field-group label{font-style:normal;}
+  #mc_embed_signup .mc-field-group.input-group label{margin-left:5px;}
+  #mc_embed_signup .mc-field-group select {height:35px;}
+  @media only screen and (min-width: 600px) {
+    #mc_embed_signup{max-width:75%; margin:0 auto;}
+  }
+</style>
+> <div id="mc_embed_signup">
+> <h3>Sign up for user testing</h3>
+>
+>
+> <form action="https://arxiv.us4.list-manage.com/subscribe/post?u=31c4aaf571c921df1fb50adee&amp;id=7cd72795aa" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+<div id="mc_embed_signup_scroll">
+<div class="mc-field-group">
+<label for="mce-EMAIL">Email Address * </label>
+<input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">
+</div>
+<div class="mc-field-group">
+<label for="mce-FNAME">First Name </label>
+<input type="text" value="" name="FNAME" class="" id="mce-FNAME">
+</div>
+<div class="mc-field-group">
+<label for="mce-LNAME">Last Name </label>
+<input type="text" value="" name="LNAME" class="" id="mce-LNAME">
+</div>
+<div class="mc-field-group">
+<label for="mce-MMERGE6">Country * </label>
+<input type="text" value="" name="MMERGE6" class="required" id="mce-MMERGE6">
+</div>
+<div class="mc-field-group">
+	<label for="mce-RESEARCH">arXiv Research Field * </label>
+	<select name="RESEARCH" class="required" id="mce-RESEARCH">
+	<option value=""></option>
+	<option value="astro-ph">astro-ph</option>
+<option value="math">math</option>
+<option value="CoRR">CoRR</option>
+<option value="q-bio">q-bio</option>
+<option value="q-fin">q-fin</option>
+<option value="stat">stat</option>
+<option value="eess">eess</option>
+<option value="econ">econ</option>
+	</select>
+</div>
+<hr>
+<div class="mc-field-group input-group">
+  <strong>(Optional) Targeted Testing Groups</strong>
+  <p>You will be automatically added to the general user testing list. In addition we have several targeted testing groups that help us expand arXiv's functionality to the broadest number of users. Select any that apply or leave blank. </p>
+  <ul>
+  <input type="hidden" value="32" name="group[55039][32]" id="mce-group[55039]-55039-3">
+  <li><input type="checkbox" value="1" name="group[55039][1]" id="mce-group[55039]-55039-0"><label for="mce-group[55039]-55039-0">Assistive Technology (if you use a screen reader, magnifier, voice command, or other assistive tools)</label></li>
+  <li><input type="checkbox" value="2" name="group[55039][2]" id="mce-group[55039]-55039-1"><label for="mce-group[55039]-55039-1">International (if your first language is not English or first culture is not USA)</label></li>
+  <li><input type="checkbox" value="4" name="group[55039][4]" id="mce-group[55039]-55039-2"><label for="mce-group[55039]-55039-2">Slow Connectivity (if you often experience slow or unreliable internet in your area)</label></li>
+  </ul>
+</div>
+<hr>
+<div id="mce-responses" class="clear">
+<div class="response" id="mce-error-response" style="display:none"></div>
+<div class="response" id="mce-success-response" style="display:none"></div>
+</div>
+<div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_31c4aaf571c921df1fb50adee_7cd72795aa" tabindex="-1" value=""></div>
+<div class="clear">
+<input type="submit" value="Submit and Join" name="subscribe" id="mc-embedded-subscribe" class="button">
+</div>
+</div>
+</form>
+</div>
+<script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';fnames[4]='MMERGE4';ftypes[4]='radio';fnames[6]='MMERGE6';ftypes[6]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>


### PR DESCRIPTION
A new docs page with a signup form that will add you to the mailchimp user testing group. See screenshot below. I hope we will migrate over from using the listserv in early January if all steps go smoothly.

![screenshot-user-testing-signup](https://user-images.githubusercontent.com/56078140/71204135-62a54780-226d-11ea-97ab-68974a3f5eaf.png)
