### PR TITLE
ARXIVNG-2986 - Add mailchimp signup form to /about section

### DIFF
--- a/about/index.md
+++ b/about/index.md
@@ -32,6 +32,7 @@ Registered users may [submit articles](/help/submit) to be announced by arXiv. S
 - [Technical Advisory Group](/about/people/technical_ad_group)
 - [Volunteer Moderators](/moderators)
 - [Volunteer Developers](people/developers)
+- [Join arXiv's User Testing Group](/about/user-testing)
 
 
 ## General Information

--- a/about/user-testing.md
+++ b/about/user-testing.md
@@ -17,7 +17,7 @@ blockquote {
 }
 </style>
 
-From time to time arXiv sends out surveys, previews to new changes, and other testing opportunities to interested users. If you would like to join our user testing group fill out the form below. User testing is integral to arXiv's development process and we welcome your feedback.
+From time to time arXiv sends out surveys, previews to new changes, and other testing opportunities to interested users. If you would like to join our user testing group, fill out the form below. User testing is integral to arXiv's development process and we welcome your feedback.
 
 We use this list only for user testing communications and never spam or share your information.
 

--- a/about/user-testing.md
+++ b/about/user-testing.md
@@ -17,10 +17,9 @@ blockquote {
 }
 </style>
 
-From time to time arXiv sends out surveys, previews to new changes, and other testing opportunities to interested users. If you would like to join our user testing group fill out the form below. User testing is integral to arXiv's development process and we welcome your feedback. We use this list only for user testing communications and never spam or share your information.
+From time to time arXiv sends out surveys, previews to new changes, and other testing opportunities to interested users. If you would like to join our user testing group fill out the form below. User testing is integral to arXiv's development process and we welcome your feedback.
 
-_(note: we recently migrated our list from an old-fashioned listserv to mailchimp. The new platform lets us acknowledge important testing criteria like geographic location and use of assistive technology. If you are already part of the user testing list but would like to contribute to a targeted testing group simply fill out the required fields, hit submit, and follow the instructions to update your existing account)_
-
+We use this list only for user testing communications and never spam or share your information.
 
 <link href="//cdn-images.mailchimp.com/embedcode/classic-10_7.css" rel="stylesheet" type="text/css">
 <style type="text/css">
@@ -33,13 +32,13 @@ _(note: we recently migrated our list from an old-fashioned listserv to mailchim
   }
 </style>
 > <div id="mc_embed_signup">
-> <h3>Sign up for user testing</h3>
+> <h3>Join arXiv's user testing group</h3>
 >
 >
 > <form action="https://arxiv.us4.list-manage.com/subscribe/post?u=31c4aaf571c921df1fb50adee&amp;id=7cd72795aa" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
 <div id="mc_embed_signup_scroll">
 <div class="mc-field-group">
-<label for="mce-EMAIL">Email Address * </label>
+<label for="mce-EMAIL">Email Address *</label>
 <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">
 </div>
 <div class="mc-field-group">
@@ -51,13 +50,13 @@ _(note: we recently migrated our list from an old-fashioned listserv to mailchim
 <input type="text" value="" name="LNAME" class="" id="mce-LNAME">
 </div>
 <div class="mc-field-group">
-<label for="mce-MMERGE6">Country * </label>
-<input type="text" value="" name="MMERGE6" class="required" id="mce-MMERGE6">
+<label for="mce-COUNTRY">Country </label>
+<input type="text" value="" name="COUNTRY" class="" id="mce-COUNTRY">
 </div>
 <div class="mc-field-group">
-	<label for="mce-RESEARCH">arXiv Research Field * </label>
-	<select name="RESEARCH" class="required" id="mce-RESEARCH">
-	<option value=""></option>
+<label for="mce-RESEARCH">arXiv Research Field * </label>
+<select name="RESEARCH" class="required" id="mce-RESEARCH">
+<option value=""></option>
 <option value="Physics">Physics</option>
 <option value="Mathematics">Mathematics</option>
 <option value="Computer Science">Computer Science</option>
@@ -66,12 +65,12 @@ _(note: we recently migrated our list from an old-fashioned listserv to mailchim
 <option value="Statistics">Statistics</option>
 <option value="Electrical Engineering and Systems Science">Electrical Engineering and Systems Science</option>
 <option value="Economics">Economics</option>
-	</select>
+</select>
 </div>
 <hr>
 <div class="mc-field-group input-group">
   <strong>(Optional) Targeted Testing Groups</strong>
-  <p>You will be automatically added to the general user testing list. In addition we have several targeted testing groups that help us expand arXiv's functionality to the broadest number of users. Select any that apply or leave blank. </p>
+  <p>You will be automatically added to the general user testing list. In addition we have targeted testing groups, select any that apply or leave blank. </p>
   <ul>
   <input type="hidden" value="32" name="group[55039][32]" id="mce-group[55039]-55039-3">
   <li><input type="checkbox" value="1" name="group[55039][1]" id="mce-group[55039]-55039-0"><label for="mce-group[55039]-55039-0">Assistive Technology (if you use a screen reader, magnifier, voice command, or other assistive tools)</label></li>
@@ -91,4 +90,4 @@ _(note: we recently migrated our list from an old-fashioned listserv to mailchim
 </div>
 </form>
 </div>
-<script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';fnames[4]='MMERGE4';ftypes[4]='radio';fnames[6]='MMERGE6';ftypes[6]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
+<script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';fnames[6]='COUNTRY';ftypes[6]='text';fnames[3]='RESEARCH';ftypes[3]='dropdown';fnames[4]='CLASS';ftypes[4]='text';fnames[5]='NOTES';ftypes[5]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>

--- a/help/policies/privacy_policy.md
+++ b/help/policies/privacy_policy.md
@@ -11,7 +11,7 @@ The privacy notice was last revised on 2019-02-08.
 
 _Information we gather for anonymous browsing:_
 
-We automatically collect certain information from you when you visit arXiv. This data is used to gather metrics on site usage including geographic location of visitors (IP address), pathways navigated through the website, what type of internet browser is used (user-agent). No attempt is made to deanonymize information we collect. 
+We automatically collect certain information from you when you visit arXiv. This data is used to gather metrics on site usage including geographic location of visitors (IP address), pathways navigated through the website, what type of internet browser is used (user-agent). No attempt is made to deanonymize information we collect.
 
 _Information you may provide as registered user:_
 
@@ -27,7 +27,7 @@ Users who choose to fill out a feedback form on the website can do so anonymousl
 
 _Information provided by others:_
 
-Users who submit articles or other content to arXiv must ensure that they have the consent to share personal data contained within the content or the submission may be removed. 
+Users who submit articles or other content to arXiv must ensure that they have the consent to share personal data contained within the content or the submission may be removed.
 
 
 ## How we use your information
@@ -53,12 +53,12 @@ _Article Submission:_
 In the content submission and moderation process we link user accounts, authorship, and submitted content to track and process submissions. More information is at: https://arxiv.org/help/submit; https://arxiv.org/help/registerhelp; https://arxiv.org/help/terms_of_submission; https://arxiv.org/help/moderation  
 
 
-Article metadata provided by submitter, including author list, author affiliation (if provided), submitter name is displayed with the article posting, email announcement of articles, and bulk metadata access via API. 
+Article metadata provided by submitter, including author list, author affiliation (if provided), submitter name is displayed with the article posting, email announcement of articles, and bulk metadata access via API.
 
 
 The email address that was used to upload each submission is viewable by registered arXiv users to give users the ability to send feedback on papers to the submitter and to help users [contact eligible arXiv endorsers](https://arxiv.org/help/endorsement#request) in order to make their own submissions.
 
-_Fundraising:_ 
+_Fundraising:_
 
 Should you decide to donate to arXiv through the donate page you will be directed to the Cornell giving website and the information you provide will be used to process your donation. Please also see the [Cornell giving privacy policy](https://giving.cornell.edu/privacy-policy/).
 
@@ -85,7 +85,8 @@ Slack is used for email communication of submission and moderator emails that ma
 
 Amazon Web Services is used for server infrastructure for components of the arXiv system.
 
-[Astrophysics Data System](http://ads.harvard.edu/) (ADS) is a trusted partner with arXiv who we share anonymized browsing logs associated with arXiv papers for use in ADS search and discovery tools. 
+
+[Astrophysics Data System](http://ads.harvard.edu/) (ADS) is a trusted partner with arXiv who we share anonymized browsing logs associated with arXiv papers for use in ADS search and discovery tools.
 
 _Info we share with moderators as part of submission and moderation:_
 
@@ -98,7 +99,7 @@ Users with registered arXiv accounts can view the email address that was used to
 The metadata for arXiv articles is freely accessible and available to any third-party use.
 
 
-## Cookies 
+## Cookies
 
 Cookies are text files stored on your computer and accessible only to the websites which create them.
 
@@ -111,14 +112,26 @@ To manage cookies in arXiv please see: https://arxiv.org/cookies
 
 No method of transmitting over the internet or storing electronic data is 100% secure, but arXiv follows standard practices to protect against the loss, misuse, or alteration of the information that is under our control.
 
+##Fundraising, Update, User Testing, and other notifications
+This section explains the choices you have when it comes to receiving email communications from arXiv.
 
-## Fundraising and Update Emails 
-
-Donors to arXiv may receive future fundraising emails from Cornell University. Those emails do contain options to unsubscribe.
+Donors to arXiv may receive future fundraising emails from Cornell University. Those emails will contain options to unsubscribe.
 
 arXiv members will receive annual update emails and direct correspondence relating to membership. Those emails will contain options to unsubscribe.
 
-Your information is never shared with any third party marketing services.
+Sorry™ App is used to notify users about arXiv's operational status. Read [Sorry's privacy page](https://help.sorryapp.com/en/articles/1929467-privacy-and-cookies-policy) for more information. When you sign up for status notifications arXiv will share your contact information with Sorry™ to keep you informed about changes in the availability of our service. You'll have the option to unsubscribe at any time.
+
+If you have joined the user testing list you will receive occasional survey links and other relevant opportunities to review and offer feedback on website changes. We use Mailchimp to manage user testing lists and send emails to our testing groups. Read [Mailchimp’s privacy policy](https://mailchimp.com/legal/privacy/) for more information. You can make changes to your email preferences by utilizing the relevant links noted in our email communications. You may opt out of user testing emails at any time.
+
+We collect a variety of types of information for user testing purposes such as:
+Your name and email
+Your country
+Your primary research field
+Your opinions on various aspects of the website.
+
+This information helps us improve the functionality of arXiv for more people and across geographic areas.
+
+Your information is never shared with third party marketing services.
 
 ## Social Media Presence
 
@@ -151,6 +164,6 @@ Please contact us with any questions, concerns, or if you wish to exercise any o
 
 ## Contact Information
 
-For questions about arXiv privacy policies or technical support please contact: help@arxiv.org 
+For questions about arXiv privacy policies or technical support please contact: help@arxiv.org
 
 If you have general questions about Cornell University privacy practices, please contact: privacy@cornell.edu or visit https://privacy.cornell.edu.


### PR DESCRIPTION
This commit makes some final updates to the embedded user testing mailchimp form code. It also adds a link to the form on the /about page.