### PR TITLE
updates API and General input names

### DIFF
--- a/about/user-testing-api.md
+++ b/about/user-testing-api.md
@@ -65,13 +65,14 @@ We use this list only for user testing communications and never spam or share yo
 <option value="Statistics">Statistics</option>
 <option value="Electrical Engineering and Systems Science">Electrical Engineering and Systems Science</option>
 <option value="Economics">Economics</option>
+<option value="Not Applicable">Not Applicable</option>
 </select>
 </div>
 <hr>
 <div class="mc-field-group input-group">
 <strong>(Optional) Do you want to join our general testing group?</strong>
 <p>From time to time arXiv sends out surveys, previews to new changes, and other testing opportunities to interested users. Your feedback helps us improve arXiv.</p>
-<ul><input type="hidden" value="128" name="group[55039][128]" id="mce-group[55039]-55039-4"><li><input type="checkbox" value="32" name="group[55039][32]" id="mce-group[55039]-55039-3"><label for="mce-group[55039]-55039-3">Yes, add me to the general user testing group</label></li></ul>
+<ul><input type="hidden" value="32" name="group[55039][32]" id="mce-group[55039]-55039-4"><li><input type="checkbox" value="16" name="group[55039][16]" id="mce-group[55039]-55039-3"><label for="mce-group[55039]-55039-3">Yes, add me to the general user testing group</label></li></ul>
 </div>
 <hr>
 <div id="mce-responses" class="clear">

--- a/about/user-testing.md
+++ b/about/user-testing.md
@@ -65,18 +65,17 @@ We use this list only for user testing communications and never spam or share yo
 <option value="Statistics">Statistics</option>
 <option value="Electrical Engineering and Systems Science">Electrical Engineering and Systems Science</option>
 <option value="Economics">Economics</option>
+<option value="Not Applicable">Not Applicable</option>
 </select>
 </div>
 <hr>
 <div class="mc-field-group input-group">
 <strong>(Optional) Targeted Testing Groups</strong>
 <p>You will be automatically added to the general user testing list. In addition we have targeted testing groups, select any that apply or leave blank. </p>
-<ul>
-<input type="hidden" value="32" name="group[55039][32]" id="mce-group[55039]-55039-3">
-<li><input type="checkbox" value="1" name="group[55039][1]" id="mce-group[55039]-55039-0"><label for="mce-group[55039]-55039-0">Assistive Technology (if you use a screen reader, magnifier, voice command, or other assistive tools)</label></li>
+<ul><input type="hidden" value="16" name="group[55039][16]" id="mce-group[55039]-55039-3"><li><input type="checkbox" value="1" name="group[55039][1]" id="mce-group[55039]-55039-0"><label for="mce-group[55039]-55039-0">Assistive Technology (if you use a screen reader, magnifier, voice command, or other assistive tools)</label></li>
 <li><input type="checkbox" value="2" name="group[55039][2]" id="mce-group[55039]-55039-1"><label for="mce-group[55039]-55039-1">International (if your first language is not English or first culture is not USA)</label></li>
 <li><input type="checkbox" value="4" name="group[55039][4]" id="mce-group[55039]-55039-2"><label for="mce-group[55039]-55039-2">Slow Connectivity (if you often experience slow or unreliable internet in your area)</label></li>
-<li><input type="checkbox" value="128" name="group[55039][128]" id="mce-group[55039]-55039-4"><label for="mce-group[55039]-55039-4">API Testing (if you use the arXiv API for development)</label></li>
+<li><input type="checkbox" value="32" name="group[55039][32]" id="mce-group[55039]-55039-4"><label for="mce-group[55039]-55039-4">API Testing (if you use the arXiv API for development)</label></li>
 </ul>
 </div>
 <hr>


### PR DESCRIPTION
I just realized today, while reviewing mailchimp, that the field names for the API group and the General group had changed on the MC backend. This means that users were automatically being signed up for the API group instead of General, and that real signups to the API group werent being accurately identified.

I believe this happened when I added the second API field (nextgen, not in use yet). @mhl10 I'll reach out with some ideas for retroactively fixing and growing the API user group. 

This commit also adds 'not applicable' as an option to the research fields dropdown.