### PR TITLE
adds new accessibility assistance page

### DIFF
--- a/help/index.md
+++ b/help/index.md
@@ -6,6 +6,7 @@ slug: Help
 
 ## General Information
 - [About arXiv](/about)
+- [Policies](/policies)
 - [arXiv Help Frequently Asked Questions](faq/index)
 
 ## Searching and Browsing
@@ -15,6 +16,7 @@ slug: Help
 - [Cookie Configuration](../cookies)
 - [Utilities (tar, gzip, etc.)](utilities)
 - [Gzipped files](gzip)
+- [Web Accessibility Assistance](web_accessibility)
 
 ## User Accounts
 - [Register a User Account](registerhelp)

--- a/help/index.md
+++ b/help/index.md
@@ -6,7 +6,7 @@ slug: Help
 
 ## General Information
 - [About arXiv](/about)
-- [Policies](/policies)
+- [Policies](policies)
 - [arXiv Help Frequently Asked Questions](faq/index)
 
 ## Searching and Browsing

--- a/help/policies/web_accessibility.md
+++ b/help/policies/web_accessibility.md
@@ -1,0 +1,4 @@
+Web Accessibility Assistance
+======================
+
+arXiv is committed to making our websites accessible to everyone, including individuals with disabilities. To report a problem or to request an accommodation to access online materials, information, resources, and/or services, please contact [web-accessibility@cornell.edu](mailto:web-accessibility@cornell.edu). In your message, include the website address or URL and the specific problems you have encountered. You will receive a reply as soon as possible.

--- a/help/policies/web_accessibility.md
+++ b/help/policies/web_accessibility.md
@@ -1,4 +1,0 @@
-Web Accessibility Assistance
-======================
-
-arXiv is committed to making our websites accessible to everyone, including individuals with disabilities. To report a problem or to request an accommodation to access online materials, information, resources, and/or services, please contact [web-accessibility@cornell.edu](mailto:web-accessibility@cornell.edu). In your message, include the website address or URL and the specific problems you have encountered. You will receive a reply as soon as possible.

--- a/help/web_accessibility.md
+++ b/help/web_accessibility.md
@@ -1,0 +1,4 @@
+Web Accessibility Assistance
+======================
+
+arXiv is committed to making our websites accessible to everyone, including individuals with disabilities. To report a problem or to request an accommodation to access online materials, information, resources, and/or services, please contact web-accessibility@cornell.edu. In your message, include the website address or URL and the specific problems you have encountered. You will receive a reply as soon as possible.


### PR DESCRIPTION
adds a new page that the footer accessibility link will take users to. The actual footer changes are taking place in the arxiv-base and arxiv-browse repos.

The content of the new page is based on this CU page, we just switched Cornell's name to arXiv: https://www.cornell.edu/accessibility-assistance.cfm