### PR TITLE
ARXIVNG-3457: add separate Dockerfile and uwsgi.ini for labs

### DIFF
--- a/Dockerfile-labs
+++ b/Dockerfile-labs
@@ -1,0 +1,44 @@
+# arxiv/docs
+#
+# This image serves up the arXiv docs sites, including Help, About, Labs,
+# CoRR, and HyperTeX Help.
+FROM arxiv/base-with-git:0.14.3
+
+WORKDIR /opt/arxiv/
+
+RUN pip install -U pip pipenv && \
+    pipenv install uwsgi arxiv-marxdown==0.2.4rc4  && \
+    rm -rf ~/.cache/pip
+
+EXPOSE 8000
+
+ARG NOCACHE=1
+ARG VERSION
+ARG BUILD_TIME
+
+ENV VERSION=$VERSION \
+    BUILD_TIME=$BUILD_TIME \
+    LOGLEVEL=40 \
+    PATH="/opt/arxiv:${PATH}" \
+    LC_ALL=en_US.utf-8 \
+    LANG=en_US.utf-8 \
+    UWSGI_PROCESSES=4
+
+# Add the /labs site.
+ADD ./deploy/labs /opt/arxiv/labs/
+COPY ./labs /opt/arxiv/labs/source/
+COPY ./.git /opt/arxiv/labs/source/.git/
+
+# Add the uwsgi config, which mounts each of the sites above.
+COPY ./deploy/uwsgi-labs.ini /opt/arxiv/uwsgi.ini
+
+# Build all sites.
+#
+# These are grouped together in a single RUN to cut down on layers.
+RUN ls -la /opt/arxiv/labs/source && \
+    pipenv run python -m arxiv.marxdown.build \
+     --build-path=/opt/arxiv/labs/build \
+     --instance-path=/opt/arxiv/labs/instance
+
+ENTRYPOINT ["pipenv", "run"]
+CMD ["uwsgi", "--ini", "/opt/arxiv/uwsgi.ini"]

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,16 @@
+# Deploy
+
+## Deploy to labs.arxiv.org
+
+### Build the image
+1. cd arxiv-docs
+1. export TAG=  ...Find a commit tag in git for the docker image tag.
+1. docker build . -t arxiv/labs:$TAG -f ./Dockerfile-labs
+1. docker push arxiv/labs:$TAG
+1. docker run -it -p 8000:8000 arxiv/labs:$TAG
+
+### Deploy the image
+1. ssh arxiv-bastion
+1. helm ls | grep labs-static
+1. export TAG=  ...the docker image tag.
+1. sh deploy/helm_upgrade_labs.sh

--- a/deploy/helm-upgrade-labs.sh
+++ b/deploy/helm-upgrade-labs.sh
@@ -1,0 +1,21 @@
+# helm-upgrade-labs.sh
+# Upgrade the content of labs.arxiv.org
+
+# The docker image tag, generally a git commit tag.
+#export TAG=...
+
+export HELM_CHART=arxiv/marxdown
+export HELM_RELEASE=labs-static
+export NAMESPACE=default
+
+helm upgrade $HELM_RELEASE $HELM_CHART \
+--set=imageName=arxiv/labs \
+--set=imageTag=$TAG \
+--set=deploymentName=arxiv-$HELM_RELEASE \
+--set=serviceName=arxiv-$HELM_RELEASE \
+--set=ingressName=$HELM_RELEASE \
+--set=host=labs.arxiv.org \
+--set=namespace=$NAMESPACE \
+--namespace $NAMESPACE \
+--recreate-pods
+

--- a/deploy/uwsgi-labs.ini
+++ b/deploy/uwsgi-labs.ini
@@ -1,0 +1,19 @@
+[uwsgi]
+http-socket = :8000
+chdir = /opt/arxiv/labs/
+wsgi-file = wsgi.py
+callable = application
+master = true
+harakiri = 3000
+manage-script-name = true
+processes = 8
+queue = 0
+threads = 1
+single-interpreter = true
+mount = $(APPLICATION_ROOT)=arxiv.marxdown.wsgi:application
+logformat = "%(addr) %(addr) - %(user_id)|%(session_id) [%(rtime)] [%(uagent)] \"%(method) %(uri) %(proto)\" %(status) %(size) %(micros) %(ttfb)"
+buffer-size = 65535
+wsgi-disable-file-wrapper = true
+
+# Labs
+static-map = /labs/static=/opt/arxiv/labs/build/static


### PR DESCRIPTION
These were used to build and deploy the image:
arxiv/labs:5b6583eea8dc557b967506f2de1e5374bace3b87

