### PR TITLE
added blurbs about file formats

### DIFF
--- a/help/faq/mistakes.md
+++ b/help/faq/mistakes.md
@@ -52,6 +52,7 @@ Look through these common mistakes if your TeX/LaTeX submission failed:
     file?](#wrongtex)
   - [Problems with inclusion of binary or other bitmap figures; `PS BAD`
     warnings](#psbad)
+  - [Mixed figure file types](#mixed)
 
 -----
 
@@ -503,3 +504,16 @@ ignored "Comments" from the PostScript standard to provide additional
 structure to regular PostScript files, which leads to complications for
 programs that rely on proper DSC structure when two or more such files
 are included in each other.
+
+
+<span id="mixed"></span> **Mixed figure file formats**
+
+arXiv does not perform any "on the fly" figure file conversions from PostScript to PDF, so your
+figure files must be in the same format expected for your processing engine. This means PDFLATeX would accept any combination of `.pdf`, `.jpg`, and/or `.png`, and that (La)TeX accepts `.ps` and/or `.eps` only. You can tell this has been done locally because the converted figures will typically appear with names like "`-eps-converted-to.pdf`" in addition to the original `.eps` file.
+
+One could convert all PostScript figures in a directory to PDF simply by running from a BASH prompt: 
+```
+  $ for i in *ps; do ps2pdf -DEPSCrop $i; done;
+```
+then proceeding to update the figure file inclusion commands in your tex. Note that there are many ways to accomplish this step (e.g. one could use [ImageMagick](/help/bitmap/procedure#shortImageM)), and this is provided as an example only. It is your responsibility as the submitter to ensure that the figures are scientifically accurate in the format as submitted. 
+

--- a/help/submit_tex.md
+++ b/help/submit_tex.md
@@ -40,9 +40,10 @@ By default, LaTeX files are processed using LaTeX2e (the current version of LaTe
 
 If you have a file named foo.tex, then do not include any associated auxiliary file or intermediate or resulting output file, e.g. foo.ps (or foo.aux, foo.log, foo.toc, foo.lot, foo.lof, foo.dvi, foo.pdf) in your submission. These will be automatically removed to allow the creation of an output file from your TeX file. Index (`.ind`) and processed bibtex (`.bbl`) files are an exception, [see below](#bibtex).
 
+<span id="figures"></span>
 #### Figure inclusion in LaTeX submissions
 
-Note that TeX/LaTeX can only include (encapsulated) PostScript (**.ps** or **.eps**), figures directly. Other formats are not supported in native (La)TeX. See [Useful Software](/help/bitmap/software) for figure conversion tools. If you are making use of [PDFLaTeX](#pdftex) you may embed your `.pdf, .png, .jpg` figures using the same mechanisms.
+Note that TeX/LaTeX can only include (encapsulated) PostScript (**.ps** or **.eps**), figures directly. Other formats are not supported in native (La)TeX. See [Useful Software](/help/bitmap/software) for figure conversion tools. If you are making use of [PDFLaTeX](#pdftex) you may embed your `.pdf, .png, .jpg` figures using the same mechanisms. Please note that arXiv does not perform "on the fly" figure file conversion during tex processing (i.e. "`-eps-converted-to.pdf`" files being present in your source directory). You must perform such conversion yourself, before uploading, updating any effected inclusion command. This process ensures that you have examined the results of any figure conversion to ensure that the figures still contain scientifically correct information and that arXiv is not responsible for the scientific accuracy of your figures.
 
 The most flexible and robust figure inclusion is provided by the `graphics` and `graphicx` packages and the `\includegraphics` command defined therein. We highly recommend you use them for your figure inclusion. arXiv does not provide the `psfig` package any longer. You must include your own `psfig.sty` if you use it. In general, if things go wrong or don't look as desired you may have to include your version of [older macros](/help/faq/mistakes#old_style).
 


### PR DESCRIPTION
These changes are attempting to circumvent the mixed file format errors and give users some guidance as to how to identify that it's been done when they're not expecting it, and how to convert their files if needed. 