### PR TITLE
ARXIVNG-3685: add labs feedback link

### DIFF
--- a/labs/_templates/labs/base.html
+++ b/labs/_templates/labs/base.html
@@ -22,7 +22,7 @@
             },
 
             account: {
-                id:           'ACCOUNT-UNIQUE-ID' // Highly recommended
+                id:           'ARXIV-LABS' // Highly recommended
                 // name:         // Optional
                 // is_paying:    // Recommended if using Pendo Feedback
                 // monthly_value:// Recommended if using Pendo Feedback

--- a/labs/index.md
+++ b/labs/index.md
@@ -80,3 +80,4 @@ $jinja {{ render_project(projects.core_recommender) }} jinja$
 $jinja {{ render_project(projects.bibliographic_overlay) }} jinja$
 
 We are grateful to the [volunteer developers](https://arxiv.org/about/people/developers) who contribute to the arXiv codebase and invite you to get involved. Please see our [guidelines for contributors](https://github.com/arXiv/.github/blob/master/CONTRIBUTING.md), or contact nextgen@arxiv.org, for more information about contributing to arXiv software development.
+If you are interested in proposing a new arXiv Labs project, please <a href="#" onclick="pendo.feedback.openFeedback(event)">submit a proposal</a>.


### PR DESCRIPTION
This adds the feedback link using Pendo's Feedback mechanism. There isn't a great to test this on my laptop so the link is intentionally not very prominent. If it's OK for now I'll get this deployed to production labs.arxiv.org (now running in Google Cloud).

<img width="1400" alt="Screen Shot 2020-11-17 at 10 32 12 AM" src="https://user-images.githubusercontent.com/746253/99410397-6fd51700-28c0-11eb-813e-699054922883.png">
