### PR TITLE
submit.md sentence rephrased for clarity

### DIFF
--- a/help/submit.md
+++ b/help/submit.md
@@ -126,7 +126,8 @@ Unsubmitting an article takes the article out of the processing queue, and annou
 Edit or replace your submission
 ----------------------------
 
-No additional versions are generated when edits are done before the submission is publicly announced.
+No additional [versions](versions) are generated when edits are done before the submission is publicly announced.
+
 The date stamp associated with the submission will
 be the time that the final "Submit Article" step is completed. Edits and
 final submission before 14:00 US Eastern Time (EDT/EST) Monday through

--- a/help/submit.md
+++ b/help/submit.md
@@ -126,7 +126,7 @@ Unsubmitting an article takes the article out of the processing queue, and annou
 Edit or replace your submission
 ----------------------------
 
-Edits before a submission is publicly announced will not generate additional versions.
+No additional versions are generated when edits are done before the submission is publicly announced.
 The date stamp associated with the submission will
 be the time that the final "Submit Article" step is completed. Edits and
 final submission before 14:00 US Eastern Time (EDT/EST) Monday through


### PR DESCRIPTION
Thanks @jweiskoff for rejecting #271 .

My new proposed wording is more robust as the sentence is broken into two parts bridged with the word 'when'.