### PR TITLE
Pre-release merge for docs 0.7.1

### DIFF
--- a/help/econ/index.md
+++ b/help/econ/index.md
@@ -15,5 +15,5 @@ The advisory committee members serve as consultants to Cornell University and to
 - Drew Fudenberg (Massachusetts Institute of Technology)
 - Adam Guren (Boston University)
 - Fabien Postel-Vinay (University College London)
-- Joerg Stoye (Cornell University)
-- Martin Weidner, Chair, (University College London)
+- Joerg Stoye, Chair, (Cornell University)
+- Martin Weidner, (University College London)


### PR DESCRIPTION
This will only publish the chair update.
Hmm, Alison is missing from the reviewers drop down.
And Jim disappeared too.