### PR TITLE
minor changes to labs proposal form iframe

### DIFF
--- a/labs/project-proposal.md
+++ b/labs/project-proposal.md
@@ -68,8 +68,8 @@ blockquote {
 </style>
 arXiv welcomes anyone, from single individuals to large companies, to contribute ideas and propose their project for arXivLabs. All projects must abide by arXiv’s values of openness, community, excellence, and user data privacy. Learn more about arXiv's [Labs criteria](criteria) and [API data usage](https://arxiv.org/help/api/).
 
-To propose a project fill out all fields in our project proposal form. Scroll within the frame below and fill out all fields on each page (total of four steps).
+To propose a project fill out all fields in our project proposal form. _Scroll within the frame_ below to access the full form and fill out all fields on each page (a total of four steps).
 
-<iframe src="https://cornell.ca1.qualtrics.com/jfe/form/SV_6utTdLVDVlaTz5Y" height="650px" width="100%" class="form-proposals" title="submit a proposal to arxiv labs"></iframe>
+<iframe src="https://cornell.ca1.qualtrics.com/jfe/form/SV_6utTdLVDVlaTz5Y" height="750px" width="100%" class="form-proposals" title="submit a proposal to arxiv labs"></iframe>
 
 _Is the form above not displaying? <a href="https://cornell.ca1.qualtrics.com/jfe/form/SV_6utTdLVDVlaTz5Y">Open it in Qualtrics</a>_


### PR DESCRIPTION
A minor change: increases the height of the iframe so that the "continue" button is more visible. 

There were a number of recent Labs proposals where the users did not go to the second page. Some were clearly spam but atleast two looked like legitimate email addresses for a researcher. My guess is that they did not scroll and see the next button. Hopefully this change will help users get to page 2, and they will then know to look for the Continue button on the subsequent pages as well.