### PR TITLE
Fix src URL examples on "arXiv identifier scheme" page

### DIFF
--- a/help/arxiv_identifier_for_services.md
+++ b/help/arxiv_identifier_for_services.md
@@ -150,7 +150,7 @@ table below:
 | Abstract (raw txt)           | `/abs/id?fmt=txt`     | `/abs/hep-th/9901001?fmt=txt`   | `/abs/0706.0001?fmt=txt`        | `/abs/1501.00001?fmt=txt` |
 | PDF                          | `/pdf/id.pdf`         | `/pdf/hep-th/9901001.pdf`       | `/pdf/0706.0001.pdf`            | `/pdf/1501.00001.pdf`     |
 | PS                           | `/ps/id`              | `/ps/hep-th/9901001`            | `/ps/0706.0001`                 | `/ps/1501.00001`          |
-| Source (.gz,.tar.gz,.pdf...) | `/src/id`             | `/src/hep-th/9901001`           | `/src/hep-th/9901001`           | `/src/0706.0001`          |
+| Source (.gz,.tar.gz,.pdf...) | `/src/id`             | `/src/hep-th/9901001`           | `/src/0706.0001`                | `/src/1501.00001`         |
 | Trackbacks                   | `/tb/id`              | `/tb/hep-th/9901001`            | `/tb/0706.0001`                 | `/tb/1501.00001`          |
 | New listings                 | `/list/arch-ive/new`  | `/list/hep-th/new`              | `/list/hep-th/new`              | `/list/hep-th/new`        |
 | Month listings               | `/list/arch-ive/yymm` | `/list/hep-th/0601`             | `/list/hep-th/0601`             | `/list/hep-th/0601`       |
@@ -197,7 +197,7 @@ contains the definitive classification information:
     From: Jens Marklof
     Date: Tue, 5 Jan 1999 15:55:02 GMT   (18kb)
     Date (revised v2): Tue, 13 Apr 1999 11:54:24 GMT   (19kb)
-     
+
     Title: Quantum unique ergodicity for parabolic maps
     Authors: Jens Marklof, Zeev Rudnick
     Categories: math-ph chao-dyn math.MP math.NT math.SP nlin.CD quant-ph

--- a/mkdocs/docs/help/arxiv_identifier_for_services.md
+++ b/mkdocs/docs/help/arxiv_identifier_for_services.md
@@ -150,7 +150,7 @@ table below:
 | Abstract (raw txt)           | `/abs/id?fmt=txt`     | `/abs/hep-th/9901001?fmt=txt`   | `/abs/0706.0001?fmt=txt`        | `/abs/1501.00001?fmt=txt` |
 | PDF                          | `/pdf/id.pdf`         | `/pdf/hep-th/9901001.pdf`       | `/pdf/0706.0001.pdf`            | `/pdf/1501.00001.pdf`     |
 | PS                           | `/ps/id`              | `/ps/hep-th/9901001`            | `/ps/0706.0001`                 | `/ps/1501.00001`          |
-| Source (.gz,.tar.gz,.pdf...) | `/src/id`             | `/src/hep-th/9901001`           | `/src/hep-th/9901001`           | `/src/0706.0001`          |
+| Source (.gz,.tar.gz,.pdf...) | `/src/id`             | `/src/hep-th/9901001`           | `/src/0706.0001`                | `/src/1501.00001`         |
 | Trackbacks                   | `/tb/id`              | `/tb/hep-th/9901001`            | `/tb/0706.0001`                 | `/tb/1501.00001`          |
 | New listings                 | `/list/arch-ive/new`  | `/list/hep-th/new`              | `/list/hep-th/new`              | `/list/hep-th/new`        |
 | Month listings               | `/list/arch-ive/yymm` | `/list/hep-th/0601`             | `/list/hep-th/0601`             | `/list/hep-th/0601`       |
@@ -197,7 +197,7 @@ contains the definitive classification information:
     From: Jens Marklof
     Date: Tue, 5 Jan 1999 15:55:02 GMT   (18kb)
     Date (revised v2): Tue, 13 Apr 1999 11:54:24 GMT   (19kb)
-     
+
     Title: Quantum unique ergodicity for parabolic maps
     Authors: Jens Marklof, Zeev Rudnick
     Categories: math-ph chao-dyn math.MP math.NT math.SP nlin.CD quant-ph


### PR DESCRIPTION
## Motivation

Two examples on the page [arXiv identifier scheme - information for interacting services](https://arxiv.org/help/arxiv_identifier_for_services) were incorrect:

+ Value in the `Example with new id (0704-1412)` column duplicated that in the `Example with old id (9107-0703)` column.
+ Value in the `Example new id (1501-)` column was the correct value for the `Example with new id (0704-1412)`

## Changes

Shifts and adds values to make the examples correct.

## Testing

Confirmed the new example URLs are valid:

+ https://arxiv.org/src/0706.0001
+ https://arxiv.org/src/1501.00001

Didn't got through the steps to build the site.