### PR TITLE
added section to help/faq/texprobs for hyperlinks overrunning lines

### DIFF
--- a/help/faq/texprobs.md
+++ b/help/faq/texprobs.md
@@ -52,6 +52,7 @@ submission replaced to correct the problems.
     ```
     
   - <span id="breaklinks"></span>**Hyperlinks overrun the page or column boundaries**
+  
     arXiv's default behavior for [hyperref](/help/hypertex) is to have hyperlinks (and any other clickable link) to remain on a single line. This means that any URL or linked text longer than the available `\columnwidth` or `\textwidth` values will not break into the next line. To disable this behavior, you must set the hyperref option `breaklinks` to be `true`. We recommend using a `\hypersetup` block, as this makes keeping your options easier to see. For example: 
     ```
         \hypersetup{

--- a/help/faq/texprobs.md
+++ b/help/faq/texprobs.md
@@ -6,6 +6,7 @@ locally. In most cases there are fixes that can be applied and the
 submission replaced to correct the problems.
 
   - [Lines in the table of contents don't wrap](#toc_links)
+  - [Hyperlinks overrun the page or column boundaries](#breaklinks)
   - [Fuzzy fonts in PDF](#fuzzy_pdf)
   - [PostScript figures lose quality in the arXiv-generated
     PDF](#distiller_params)
@@ -50,8 +51,18 @@ submission replaced to correct the problems.
         \usepackage[hyperindex,breaklinks]{hyperref}
     ```
     
-      
-
+  - <span id="breaklinks"></span>**Hyperlinks overrun the page or column boundaries**
+    arXiv's default behavior for [hyperref](/help/hypertex) is to have hyperlinks and any other clickable link to remain on a single line. This means that any URL or linked text that is longer than the available space will be placed on a single line. To disable this behavior, you must set the hyperref option `breaklinks` to be `true`. We recommend using a `\hypersetup` block, as this makes keeping your options easier to see. For example: 
+    ```
+        \hypersetup{
+           breaklinks=true, % splits links across lines
+           colorlinks=true, % displays links as colored text instead of blocks
+           pdfusetitle=true, % \title and \author values into pdf metadata
+           % etc.
+        }
+    ```
+    For more information please consult the [hyperref manual](https://ctan.org/pkg/hyperref). 
+    
   - <span id="fuzzy_pdf"></span>**Fuzzy fonts in PDF**  
     If you use the `fontenc` package and `T1` fonts you may find that
     the fonts appear fuzzy in PDF output from arXiv. Our suggested

--- a/help/faq/texprobs.md
+++ b/help/faq/texprobs.md
@@ -52,13 +52,13 @@ submission replaced to correct the problems.
     ```
     
   - <span id="breaklinks"></span>**Hyperlinks overrun the page or column boundaries**
-    arXiv's default behavior for [hyperref](/help/hypertex) is to have hyperlinks and any other clickable link to remain on a single line. This means that any URL or linked text that is longer than the available space will be placed on a single line. To disable this behavior, you must set the hyperref option `breaklinks` to be `true`. We recommend using a `\hypersetup` block, as this makes keeping your options easier to see. For example: 
+    arXiv's default behavior for [hyperref](/help/hypertex) is to have hyperlinks (and any other clickable link) to remain on a single line. This means that any URL or linked text longer than the available `\columnwidth` or `\textwidth` values will not break into the next line. To disable this behavior, you must set the hyperref option `breaklinks` to be `true`. We recommend using a `\hypersetup` block, as this makes keeping your options easier to see. For example: 
     ```
         \hypersetup{
-           breaklinks=true, % splits links across lines
-           colorlinks=true, % displays links as colored text instead of blocks
-           pdfusetitle=true, % \title and \author values into pdf metadata
-           % etc.
+           breaklinks=true,   % splits links across lines
+           colorlinks=true,   % displays links as colored text instead of blocks
+           pdfusetitle=true,  % \title and \author values into pdf metadata
+                              % etc.
         }
     ```
     For more information please consult the [hyperref manual](https://ctan.org/pkg/hyperref). 


### PR DESCRIPTION
Explains the hyperlink overrunning borders issue, and provides details on a fix.