### PR TITLE
Quad 220 ourmembers update

### DIFF
--- a/about/ourmembers.md
+++ b/about/ourmembers.md
@@ -1,10 +1,8 @@
-# Our Members
+# Our Members: 2022
 
 We gratefully acknowledge the support of the following members, which contribute expertise and funding that complements support from [foundations, affiliates, and sponsors](supporters).
 
 Interested in supporting arXiv and expanding the possibilities of open science? Learn more about [arXiv's funding](funding) and contact us at membership@arXiv.org.
-
-(*This page will reflect recent changes to the [membership program](membership) in 2022*)
 
 <style>
 ol {
@@ -98,6 +96,7 @@ aside {
 1. Carnegie Mellon University (USA)
 1. Columbia University (USA)
 1. CSIC - Spanish National Research Council (Spain)
+1. DESY (HGF - Helmholtz Association, German Research Centers) (Germany) _arXiv-DH and HGF_
 1. Duke University (USA)
 1. ETH Zurich (Switzerland)
 1. Fermilab (USA)
@@ -127,6 +126,7 @@ aside {
 1. Universität Heidelberg (Germany) _arXiv-DH and HGF_
 1. Universität Mainz (Germany) _arXiv-DH and HGF_
 1. University of Amsterdam  (Netherlands)
+1. University of Arizona (USA)
 1. University of British Columbia (Canada)
 1. University of California, Berkeley (USA) _CDL_
 1. University of California, Los Angeles (USA) _CDL_
@@ -146,10 +146,10 @@ aside {
 1. Yale University (USA)
 
 ## Frequent Submitters
+1. Aalto University (Finland)
 1. Argonne National Lab (USA)
 1. Boston University (USA)
 1. Brown University (USA)
-1. DESY (HGF - Helmholtz Association, German Research Centers) (Germany) _arXiv-DH and HGF_
 1. Forschungszentrum Julich (Germany) _arXiv-DH and HGF_
 1. Freie Universität Berlin  (Germany) _arXiv-DH and HGF_
 1. Humboldt-Universität zu Berlin  (Germany) _arXiv-DH and HGF_
@@ -160,7 +160,6 @@ aside {
 1. Hokkaido University  (Japan) _NII Japan Consortium_
 1. Iowa State University (USA)
 1. Joint Institute for Nuclear Research (JINR) (Russia)
-1. Kansas State University (USA)
 1. Keio University (Japan) _NII Japan Consortium_
 1. KEK High Energy Accelerator Research Organization (Japan) _NII Japan Consortium_
 1. King Abdullah University of Science and Technology (KAUST) (Saudi Arabia)
@@ -206,18 +205,20 @@ aside {
 1. Université de Montréal (Canada)
 1. Universitetet Oslo (Norway)
 1. University at Buffalo (USA)
+1. University of Adelaide (Australia)
+1. University of Alberta (Canada)
+1. University of Bern  (Switzerland)
 1. University of California, Davis (USA) _CDL_
 1. University of California, Irvine (USA) _CDL_
 1. University of California, Riverside  (USA) _CDL_
 1. University of California, Santa Cruz (USA) _CDL_
-1. University of Adelaide (Australia)
-1. University of Alberta (Canada)
 1. University of Cape Town (South Africa)
 1. University of Florida (USA)
 1. University of Groningen  (Netherlands)
 1. University of Helsinki (Finland)
 1. University of Illinois at Urbana-Champaign  (USA) _BTAA_
 1. University of Innsbruck (Austria)
+1. University of Arkansas (USA)
 1. University of Iowa (USA) _BTAA_
 1. University of Massachusetts (USA)
 1. University of Melbourne (Australia)
@@ -279,96 +280,6 @@ aside {
 1. Universität Würzburg (Germany) _arXiv-DH and HGF_
 
 
-## Platinum Members
-
->1. Imperial College London (UK) _JISC_
->1. University of Cambridge (UK) _JISC_
-
-## Tier 1
-
-1. Ecole Polytechnique Fédérale de Lausanne (EPFL)  (Switzerland)
-1. University College London  (UK) _JISC_
-1. University of Oxford  (UK) _JISC_
-
-## Tier 2
-
-1. The Chinese University of Hong Kong (Hong Kong)
-1. Durham University (UK) _JISC_
-1. University of Edinburgh (UK) _JISC_
-1. University of Texas at Austin (USA)
-
-## Tier 3
-
-1. Chalmers University of Technology  (Sweden)
-1. Commissariat à l'Énergie Atomique (CEA) (France) _CCSD_
-1. Delft University of Technology  (Netherlands)
-1. International Centre for Theoretical Physics (ICTP) (Italy)
-1. Italian Institute for Astrophysics (INAF) (Italy)
-1. Stockholm University (Sweden)
-
-1. University of Bristol (UK) _JISC_
-1. University of Manchester (UK) _JISC_
-1. University of Southern California (USA)
-
-1. University of Warwick (UK) _JISC_
-1. University of Washington Libraries (USA)
-1. University of Zurich, Institute of Theoretical Physics  (Switzerland)
-1. UPMC (Universite Pierre and Marie Curie) (France) _CCSD_
-
-## Tier 4
-
-
-1. Johns Hopkins University (USA)
-
-1. Physical Research Laboratory (2016-2020 membership sponsored by Anurag Acharya) (India)
-1. Radboud University (Netherlands)
-1. Tel Aviv University (Israel)
-1. Texas A&M University  (USA)
-
-1. TU Wien (Austria)
-
-1. Université Paris-Sud (France) _CCSD_
-1. University of Bern  (Switzerland)
-1. University of Sheffield (UK) _JISC_
-1. University of Southampton (UK) _JISC_
-1. University of Sussex (UK) _JISC_
-
-## Tier 5
-
-1. Aalto University (Finland)
-1. King's College London (UK) _JISC_
-1. Lund University Libraries, Lund University (Sweden)
-1. Tata Institute of Fundamental Research (2016-2020 membership sponsored by Anurag Acharya) (India)
-
-1. University of Glasgow (UK) _JISC_
-1. University of New South Wales, Sydney (Australia)
-1. University of Utah (USA)
-1. Washington University in St. Louis  (USA)
-
-## Tier 6
-
-1. Bibliothèque de l'Observatoire de Paris (OBSPM) (France) _CCSD_
-1. Dublin Institute for Advanced Studies (Ireland)
-1. Free University of Amsterdam (Netherlands)
-1. George Washington University (USA)
-1. Harish-Chandra Research Institute (2016-2020 membership sponsored by Anurag Acharya) (India)
-
-1. IHEP, National Science Library, CAS (China)
-1. TRIUMF (Canada)
-
-1. Université de Grenoble Alpes (France) _CCSD_
-1. Université de Rennes 1 (France) _CCSD_
-1. University of Arizona (USA)
-1. University of Birmingham (UK) _JISC_
-1. University of Cardiff (UK) _JISC_
-1. University of Graz (Austria)
-1. University of Geneva (Switzerland)
-1. University of Hawaii (USA)
-1. University of Kansas (USA)
-1. University of Nottingham (UK) _JISC_
-1. University of Pittsburgh (USA)
-1. University of Witwatersrand (South Africa)
-1. Utrecht University (Netherlands)
 
 
 

--- a/about/ourmembers.md
+++ b/about/ourmembers.md
@@ -103,6 +103,7 @@ aside {
 1. Fermilab (USA)
 1. Harvard University (USA)
 1. Indiana University (USA) _BTAA_
+1. Karlsruher Institut für Technologie (Germany) _arXiv-DH and HGF_
 1. KTH Royal Institute of Technology  (Sweden)
 1. Lawrence Berkeley National Laboratory (USA) _CDL_
 1. Los Alamos National Laboratory  (USA)
@@ -115,10 +116,15 @@ aside {
 1. Princeton University (USA)
 1. Purdue University (USA) _BTAA_
 1. Rutgers University (USA) _BTAA_
+1. RWTH Aachen  (Germany) _arXiv-DH and HGF_
 1. SISSA (Scuola Internazionale Superiore di Studi Avanzati) (Italy)
 1. Stanford University, and SLAC (USA)
+1. Technische Universität München (Germany) _arXiv-DH and HGF_
 1. Texas A&M University (USA)
 1. Tsinghua University  (China)
+1. Universität Bonn  (Germany) _arXiv-DH and HGF_
+1. Universität Heidelberg (Germany) _arXiv-DH and HGF_
+1. Universität Mainz (Germany) _arXiv-DH and HGF_
 1. University of Amsterdam  (Netherlands)
 1. University of British Columbia (Canada)
 1. University of California, Berkeley (USA) _CDL_
@@ -141,10 +147,14 @@ aside {
 1. Argonne National Lab (USA)
 1. Boston University (USA)
 1. Brown University (USA)
+1. DESY (HGF - Helmholtz Association, German Research Centers) (Germany) _arXiv-DH and HGF_
+1. Forschungszentrum Julich (Germany) _arXiv-DH and HGF_
+1. Freie Universität Berlin  (Germany) _arXiv-DH and HGF_
+1. Humboldt-Universität zu Berlin  (Germany) _arXiv-DH and HGF_
 1. George Mason University (USA)
 1. Ghent University Libraries (Belgium)
 1. Hebrew University of Jerusalem (Israel)
-1. Iowa State University
+1. Iowa State University (USA)
 1. Kansas State University (USA)
 1. King Abdullah University of Science and Technology (KAUST) (Saudi Arabia)
 1. Leiden University (Leiden Institute of Physics) (Netherlands)
@@ -157,9 +167,27 @@ aside {
 1. Rice University (USA)
 1. Simon Fraser University (Canada)
 1. Stony Brook University (USA)
-1. Syracuse University
+1. Syracuse University (USA)
+1. Technische Universität Berlin  (Germany) _arXiv-DH and HGF_
+1. Technische Universität Darmstadt (Germany) _arXiv-DH and HGF_
+1. Technische Universität Dortmund (Germany) _arXiv-DH and HGF_
 1. Tufts University (USA)
 1. Universität Basel (Switzerland)
+1. Universität Bielefeld  (Germany) _arXiv-DH and HGF_
+1. Universität Bochum (Germany) _arXiv-DH and HGF_
+1. Universität des Saarlandes (Germany) _arXiv-DH and HGF_
+1. Universität Erlangen-Nürnberg  (Germany) _arXiv-DH and HGF_
+1. Universität Frankfurt am Main  (Germany) _arXiv-DH and HGF_
+1. Universität Freiburg (Germany) _arXiv-DH and HGF_
+1. Universität Hamburg  (Germany) _arXiv-DH and HGF_
+1. Universität Hannover  (Germany) _arXiv-DH and HGF_
+1. Universität Jena (Germany) _arXiv-DH and HGF_
+1. Universität Regensburg  (Germany) _arXiv-DH and HGF_
+1. Universität Stuttgart (Germany) _arXiv-DH and HGF_
+1. Universität zu Köln  (Germany) _arXiv-DH and HGF_
+1. Universität-Münster (Germany) _arXiv-DH and HGF_
+1. Universität Tübingen  (Germany) _arXiv-DH and HGF_
+1. Universität Ulm (Germany) _arXiv-DH and HGF_
 1. Université de Montréal (Canada)
 1. Universitetet Oslo (Norway)
 1. University at Buffalo (USA)
@@ -211,6 +239,8 @@ aside {
 1. Research Centre for Astronomy and Earth Sciences (Hungary)
 1. Technion - Israel Institute of Technology  (Israel)
 1. Universität Graz (Austria)
+1. Universität Konstanz (Germany) _arXiv-DH and HGF_
+1. Universität Mannheim (Germany) _arXiv-DH and HGF_
 1. University of Arkansas (USA)
 1. University of Auckland (New Zealand)
 1. University of California, Merced (USA) _CDL_
@@ -225,7 +255,7 @@ aside {
 1. Villanova (USA)
 1. Virginia Tech (USA)
 1. Washington State University (USA)
-
+1. Universität Würzburg (Germany) _arXiv-DH and HGF_
 
 
 ## Platinum Members
@@ -235,7 +265,7 @@ aside {
 
 ## Tier 1
 
-1. DESY (HGF - Helmholtz Association, German Research Centers) (Germany) _arXiv-DH and HGF_
+
 1. Ecole Polytechnique Fédérale de Lausanne (EPFL)  (Switzerland)
 1. Kyoto University  (Japan) _NII Japan Consortium_
 1. University College London  (UK) _JISC_
@@ -246,9 +276,6 @@ aside {
 
 1. The Chinese University of Hong Kong (Hong Kong)
 1. Durham University (UK) _JISC_
-1. Karlsruher Institut für Technologie (Germany) _arXiv-DH and HGF_
-1. Universität Bonn  (Germany) _arXiv-DH and HGF_
-1. Universität Heidelberg (Germany) _arXiv-DH and HGF_
 1. University of Edinburgh (UK) _JISC_
 1. University of Texas at Austin (USA)
 
@@ -262,15 +289,12 @@ aside {
 1. KU Leuven (Belgium)
 1. Nagoya University  (Japan) _NII Japan Consortium_
 1. Osaka University (Japan) _NII Japan Consortium_
-1. RWTH Aachen  (Germany) _arXiv-DH and HGF_
 1. Stockholm University (Sweden)
-1. Technische Universität Berlin  (Germany) _arXiv-DH and HGF_
-1. Technische Universität Darmstadt (Germany) _arXiv-DH and HGF_
-1. Technische Universität München (Germany) _arXiv-DH and HGF_
+
+
 1. Tohoku University (Japan) _NII Japan Consortium_
-1. Universität Freiburg (Germany) _arXiv-DH and HGF_
-1. Universität Hamburg  (Germany) _arXiv-DH and HGF_
-1. Universität Mainz (Germany) _arXiv-DH and HGF_
+
+
 1. University of Bristol (UK) _JISC_
 1. University of Manchester (UK) _JISC_
 1. University of Southern California (USA)
@@ -282,8 +306,7 @@ aside {
 
 ## Tier 4
 
-1. Freie Universität Berlin  (Germany) _arXiv-DH and HGF_
-1. Humboldt-Universität zu Berlin  (Germany) _arXiv-DH and HGF_
+
 1. Johns Hopkins University (USA)
 1. Joint Institute for Nuclear Research (JINR)  (Russia)
 1. KEK High Energy Accelerator Research Organization (Japan) _NII Japan Consortium_
@@ -293,13 +316,7 @@ aside {
 1. Texas A&M University  (USA)
 1. Tokyo Institute of Technology Library (Japan) _NII Japan Consortium_
 1. TU Wien (Austria)
-1. Universität Erlangen-Nürnberg  (Germany) _arXiv-DH and HGF_
-1. Universität Frankfurt am Main  (Germany) _arXiv-DH and HGF_
-1. Universität Hannover  (Germany) _arXiv-DH and HGF_
-1. Universität Regensburg  (Germany) _arXiv-DH and HGF_
-1. Universität Stuttgart (Germany) _arXiv-DH and HGF_
-1. Universität zu Köln  (Germany) _arXiv-DH and HGF_
-1. Universität-Münster (Germany) _arXiv-DH and HGF_
+
 1. Université Paris-Sud (France) _CCSD_
 1. University of Bern  (Switzerland)
 1. University of Sheffield (UK) _JISC_
@@ -309,7 +326,6 @@ aside {
 ## Tier 5
 
 1. Aalto University (Finland)
-1. Forschungszentrum Julich (Germany) _arXiv-DH and HGF_
 1. Keio University (Japan) _NII Japan Consortium_
 1. King's College London (UK) _JISC_
 1. Kyushu University (Japan) _NII Japan Consortium_
@@ -317,13 +333,7 @@ aside {
 1. National Astronomical Observatory of Japan (Japan) _NII Japan Consortium_
 1. Tata Institute of Fundamental Research (2016-2020 membership sponsored by Anurag Acharya) (India)
 1. Tokyo University of Science (Japan) _NII Japan Consortium_
-1. Universität Bielefeld  (Germany) _arXiv-DH and HGF_
-1. Universität Bochum (Germany) _arXiv-DH and HGF_
-1. Universität Jena (Germany) _arXiv-DH and HGF_
-1. Universität des Saarlandes (Germany) _arXiv-DH and HGF_
-1. Universität Tübingen  (Germany) _arXiv-DH and HGF_
-1. Universität Ulm (Germany) _arXiv-DH and HGF_
-1. Universität Würzburg (Germany) _arXiv-DH and HGF_
+
 1. University of Glasgow (UK) _JISC_
 1. University of New South Wales, Sydney (Australia)
 1. University of Utah (USA)
@@ -342,10 +352,8 @@ aside {
 1. Hokkaido University  (Japan) _NII Japan Consortium_
 1. IHEP, National Science Library, CAS (China)
 1. Kobe University (Japan) _NII Japan Consortium_
-1. Technische Universität Dortmund (Germany) _arXiv-DH and HGF_
 1. TRIUMF (Canada)
-1. Universität Konstanz (Germany) _arXiv-DH and HGF_
-1. Universität Mannheim (Germany) _arXiv-DH and HGF_
+
 1. Université de Grenoble Alpes (France) _CCSD_
 1. Université de Rennes 1 (France) _CCSD_
 1. University of Arizona (USA)

--- a/about/ourmembers.md
+++ b/about/ourmembers.md
@@ -164,6 +164,7 @@ aside {
 1. KEK High Energy Accelerator Research Organization (Japan) _NII Japan Consortium_
 1. King Abdullah University of Science and Technology (KAUST) (Saudi Arabia)
 1. Kobe University (Japan) _NII Japan Consortium_
+1. KU Leuven (Belgium)
 1. Kyushu University (Japan) _NII Japan Consortium_
 1. Leiden University (Leiden Institute of Physics) (Netherlands)
 1. McGill University (Canada)
@@ -300,7 +301,6 @@ aside {
 1. Delft University of Technology  (Netherlands)
 1. International Centre for Theoretical Physics (ICTP) (Italy)
 1. Italian Institute for Astrophysics (INAF) (Italy)
-1. KU Leuven (Belgium)
 1. Stockholm University (Sweden)
 
 1. University of Bristol (UK) _JISC_

--- a/about/ourmembers.md
+++ b/about/ourmembers.md
@@ -92,6 +92,7 @@ aside {
 >1. NII Japan Consortium (Japan)
 
 ## Top 100 Submitters
+1. Arizona State University (USA)
 1. Australian National University (Australia)
 1. Brookhaven National Laboratory (USA)
 1. Carnegie Mellon University (USA)
@@ -101,23 +102,39 @@ aside {
 1. ETH Zurich (Switzerland)
 1. Fermilab (USA)
 1. Harvard University (USA)
+1. Indiana University (USA) _BTAA_
 1. KTH Royal Institute of Technology  (Sweden)
+1. Lawrence Berkeley National Laboratory (USA) _CDL_
 1. Los Alamos National Laboratory  (USA)
 1. Max Planck Digital Library (Germany)
+1. Michigan State University (USA) _BTAA_
 1. New York University (USA)
+1. Northwestern University (USA) _BTAA_
+1. Ohio State University (USA) _BTAA_
+1. Penn State University (USA) _BTAA_
 1. Princeton University (USA)
+1. Purdue University (USA) _BTAA_
+1. Rutgers University (USA) _BTAA_
 1. SISSA (Scuola Internazionale Superiore di Studi Avanzati) (Italy)
 1. Stanford University, and SLAC (USA)
 1. Texas A&M University (USA)
 1. Tsinghua University  (China)
 1. University of Amsterdam  (Netherlands)
-1. Arizona State University (USA)
 1. University of British Columbia (Canada)
+1. University of California, Berkeley (USA) _CDL_
+1. University of California, Los Angeles (USA) _CDL_
+1. University of California, San Diego (USA) _CDL_
+1. University of California, Santa Barbara (USA) _CDL_
+1. University of Chicago (USA) _BTAA_
 1. University of Colorado (USA)
+1. University of Maryland (USA) _BTAA_
+1. University of Michigan  (USA) _BTAA_
+1. University of Minnesota (USA) _BTAA_
 1. University of Pennsylvania (USA)
 1. University of Sydney (Australia)
 1. University of Toronto (Canada)
 1. University of Waterloo  (Canada)
+1. University of Wisconsin, Madison (USA) _BTAA_
 1. Yale University (USA)
 
 ## Frequent Submitters
@@ -146,13 +163,19 @@ aside {
 1. Université de Montréal (Canada)
 1. Universitetet Oslo (Norway)
 1. University at Buffalo (USA)
+1. University of California, Davis (USA) _CDL_
+1. University of California, Irvine (USA) _CDL_
+1. University of California, Riverside  (USA) _CDL_
+1. University of California, Santa Cruz (USA) _CDL_
+1. University of Adelaide (Australia)
 1. University of Alberta (Canada)
 1. University of Cape Town (South Africa)
 1. University of Florida (USA)
 1. University of Groningen  (Netherlands)
 1. University of Helsinki (Finland)
+1. University of Illinois at Urbana-Champaign  (USA) _BTAA_
 1. University of Innsbruck (Austria)
-1. University of Adelaide (Australia)
+1. University of Iowa (USA) _BTAA_
 1. University of Massachusetts (USA)
 1. University of Melbourne (Australia)
 1. University of North Carolina (USA)
@@ -190,8 +213,11 @@ aside {
 1. Universität Graz (Austria)
 1. University of Arkansas (USA)
 1. University of Auckland (New Zealand)
+1. University of California, Merced (USA) _CDL_
+1. University of California, San Francisco (USA) _CDL_
 1. University of Central Oklahoma (USA)
 1. University of Georgia (USA)
+1. University of Nebraska (USA) _BTAA_
 1. University of New Hampshire (USA)
 1. University of North Texas (USA)
 1. University of Wollongong (Australia)
@@ -213,8 +239,6 @@ aside {
 1. Ecole Polytechnique Fédérale de Lausanne (EPFL)  (Switzerland)
 1. Kyoto University  (Japan) _NII Japan Consortium_
 1. University College London  (UK) _JISC_
-1. University of California, Berkeley (USA) _CDL_
-1. University of Illinois at Urbana-Champaign  (USA) _BTAA_
 1. University of Oxford  (UK) _JISC_
 1. University of Tokyo  (Japan) _NII Japan Consortium_
 
@@ -223,30 +247,21 @@ aside {
 1. The Chinese University of Hong Kong (Hong Kong)
 1. Durham University (UK) _JISC_
 1. Karlsruher Institut für Technologie (Germany) _arXiv-DH and HGF_
-1. Rutgers University (USA) _BTAA_
 1. Universität Bonn  (Germany) _arXiv-DH and HGF_
 1. Universität Heidelberg (Germany) _arXiv-DH and HGF_
-1. University of California, Los Angeles (USA) _CDL_
-1. University of California, Santa Barbara (USA) _CDL_
 1. University of Edinburgh (UK) _JISC_
-1. University of Maryland (USA) _BTAA_
-1. University of Minnesota (USA) _BTAA_
 1. University of Texas at Austin (USA)
-1. University of Wisconsin, Madison (USA) _BTAA_
 
 ## Tier 3
 
 1. Chalmers University of Technology  (Sweden)
 1. Commissariat à l'Énergie Atomique (CEA) (France) _CCSD_
 1. Delft University of Technology  (Netherlands)
-1. Indiana University (USA) _BTAA_
 1. International Centre for Theoretical Physics (ICTP) (Italy)
 1. Italian Institute for Astrophysics (INAF) (Italy)
 1. KU Leuven (Belgium)
 1. Nagoya University  (Japan) _NII Japan Consortium_
-1. Northwestern University (USA) _BTAA_
 1. Osaka University (Japan) _NII Japan Consortium_
-1. Purdue University (USA) _BTAA_
 1. RWTH Aachen  (Germany) _arXiv-DH and HGF_
 1. Stockholm University (Sweden)
 1. Technische Universität Berlin  (Germany) _arXiv-DH and HGF_
@@ -257,11 +272,7 @@ aside {
 1. Universität Hamburg  (Germany) _arXiv-DH and HGF_
 1. Universität Mainz (Germany) _arXiv-DH and HGF_
 1. University of Bristol (UK) _JISC_
-1. University of California, Davis (USA) _CDL_
-1. University of California, San Diego (USA) _CDL_
-1. University of Chicago (USA) _BTAA_
 1. University of Manchester (UK) _JISC_
-1. University of Michigan  (USA) _BTAA_
 1. University of Southern California (USA)
 1. University of Technology Sydney (Australia)
 1. University of Warwick (UK) _JISC_
@@ -276,7 +287,6 @@ aside {
 1. Johns Hopkins University (USA)
 1. Joint Institute for Nuclear Research (JINR)  (Russia)
 1. KEK High Energy Accelerator Research Organization (Japan) _NII Japan Consortium_
-1. Penn State University (USA) _BTAA_
 1. Physical Research Laboratory (2016-2020 membership sponsored by Anurag Acharya) (India)
 1. Radboud University (Netherlands)
 1. Tel Aviv University (Israel)
@@ -292,7 +302,6 @@ aside {
 1. Universität-Münster (Germany) _arXiv-DH and HGF_
 1. Université Paris-Sud (France) _CCSD_
 1. University of Bern  (Switzerland)
-1. University of California, Santa Cruz (USA) _CDL_
 1. University of Sheffield (UK) _JISC_
 1. University of Southampton (UK) _JISC_
 1. University of Sussex (UK) _JISC_
@@ -333,9 +342,6 @@ aside {
 1. Hokkaido University  (Japan) _NII Japan Consortium_
 1. IHEP, National Science Library, CAS (China)
 1. Kobe University (Japan) _NII Japan Consortium_
-1. Lawrence Berkeley National Laboratory (USA) _CDL_
-1. Michigan State University (USA) _BTAA_
-1. Ohio State University (USA) _BTAA_
 1. Technische Universität Dortmund (Germany) _arXiv-DH and HGF_
 1. TRIUMF (Canada)
 1. Universität Konstanz (Germany) _arXiv-DH and HGF_
@@ -344,17 +350,11 @@ aside {
 1. Université de Rennes 1 (France) _CCSD_
 1. University of Arizona (USA)
 1. University of Birmingham (UK) _JISC_
-1. University of California, Irvine (USA) _CDL_
-1. University of California, Merced (USA) _CDL_
-1. University of California, Riverside  (USA) _CDL_
-1. University of California, San Francisco (USA) _CDL_
 1. University of Cardiff (UK) _JISC_
 1. University of Graz (Austria)
 1. University of Geneva (Switzerland)
 1. University of Hawaii (USA)
-1. University of Iowa (USA) _BTAA_
 1. University of Kansas (USA)
-1. University of Nebraska (USA) _BTAA_
 1. University of Nottingham (UK) _JISC_
 1. University of Pittsburgh (USA)
 1. University of Tsukuba (Japan) _NII Japan Consortium_

--- a/about/ourmembers.md
+++ b/about/ourmembers.md
@@ -309,7 +309,7 @@ aside {
 1. Tata Institute of Fundamental Research (2016-2020 membership sponsored by Anurag Acharya) (India)
 1. Tokyo University of Science (Japan) _NII Japan Consortium_
 1. Universität Bielefeld  (Germany) _arXiv-DH and HGF_
-1. Universität Bochum  (Germany) _arXiv-DH and HGF_
+1. Universität Bochum (Germany) _arXiv-DH and HGF_
 1. Universität Jena (Germany) _arXiv-DH and HGF_
 1. Universität des Saarlandes (Germany) _arXiv-DH and HGF_
 1. Universität Tübingen  (Germany) _arXiv-DH and HGF_
@@ -325,7 +325,6 @@ aside {
 
 1. Ames Laboratory (USA)
 1. Bibliothèque de l'Observatoire de Paris (OBSPM) (France) _CCSD_
-1. Case Western Reserve University (USA)
 1. Dublin Institute for Advanced Studies (Ireland)
 1. Free University of Amsterdam (Netherlands)
 1. George Washington University (USA)

--- a/about/ourmembers.md
+++ b/about/ourmembers.md
@@ -107,7 +107,7 @@ aside {
 1. KTH Royal Institute of Technology  (Sweden)
 1. Kyoto University  (Japan) _NII Japan Consortium_
 1. Lawrence Berkeley National Laboratory (USA) _CDL_
-1. Los Alamos National Laboratory  (USA)
+1. Los Alamos National Laboratory (USA)
 1. Max Planck Digital Library (Germany)
 1. Michigan State University (USA) _BTAA_
 1. New York University (USA)
@@ -159,6 +159,7 @@ aside {
 1. Hiroshima University (Japan) _NII Japan Consortium_
 1. Hokkaido University  (Japan) _NII Japan Consortium_
 1. Iowa State University (USA)
+1. Joint Institute for Nuclear Research (JINR) (Russia)
 1. Kansas State University (USA)
 1. Keio University (Japan) _NII Japan Consortium_
 1. KEK High Energy Accelerator Research Organization (Japan) _NII Japan Consortium_
@@ -174,7 +175,7 @@ aside {
 1. National Astronomical Observatory of Japan (Japan) _NII Japan Consortium_
 1. National Taiwan University (Taiwan)
 1. Osaka University (Japan) _NII Japan Consortium_
-1. Perimeter Institute for Theoretical Physics  (Canada)
+1. Perimeter Institute for Theoretical Physics (Canada)
 1. Queensland University of Technology (Australia)
 1. Rice University (USA)
 1. Simon Fraser University (Canada)
@@ -237,8 +238,9 @@ aside {
 1. Western University (Canada)
 
 ## Regular Submitters & Community Contributors
+1. Ames Laboratory (USA)
 1. Boston College (USA)
-1. Central European University (Hungary)
+1. Central European University (Austria)
 1. European Southern Observatory (Germany)
 1. Georgetown University (USA)
 1. Institute for Advanced Study (USA)
@@ -254,7 +256,7 @@ aside {
 1. Queens University (Canada)
 1. Raman Research Institute (India)
 1. Research Centre for Astronomy and Earth Sciences (Hungary)
-1. Technion - Israel Institute of Technology  (Israel)
+1. Technion - Israel Institute of Technology (Israel)
 1. Tokyo University of Science (Japan) _NII Japan Consortium_
 1. Universität Graz (Austria)
 1. Universität Konstanz (Germany) _arXiv-DH and HGF_
@@ -269,6 +271,7 @@ aside {
 1. University of New Hampshire (USA)
 1. University of North Texas (USA)
 1. University of Wollongong (Australia)
+1. University of York (UK) _JISC_
 1. Victoria University of Wellington (New Zealand)
 1. Villanova (USA)
 1. Virginia Tech (USA)
@@ -316,7 +319,7 @@ aside {
 
 
 1. Johns Hopkins University (USA)
-1. Joint Institute for Nuclear Research (JINR)  (Russia)
+
 1. Physical Research Laboratory (2016-2020 membership sponsored by Anurag Acharya) (India)
 1. Radboud University (Netherlands)
 1. Tel Aviv University (Israel)
@@ -344,7 +347,6 @@ aside {
 
 ## Tier 6
 
-1. Ames Laboratory (USA)
 1. Bibliothèque de l'Observatoire de Paris (OBSPM) (France) _CCSD_
 1. Dublin Institute for Advanced Studies (Ireland)
 1. Free University of Amsterdam (Netherlands)
@@ -366,7 +368,6 @@ aside {
 1. University of Nottingham (UK) _JISC_
 1. University of Pittsburgh (USA)
 1. University of Witwatersrand (South Africa)
-1. University of York (UK) _JISC_
 1. Utrecht University (Netherlands)
 
 

--- a/about/ourmembers.md
+++ b/about/ourmembers.md
@@ -102,6 +102,7 @@ aside {
 1. Fermilab (USA)
 1. Harvard University (USA)
 1. Indiana University (USA) _BTAA_
+1. Johns Hopkins University (USA)
 1. Karlsruher Institut für Technologie (Germany) _arXiv-DH and HGF_
 1. KTH Royal Institute of Technology  (Sweden)
 1. Kyoto University  (Japan) _NII Japan Consortium_

--- a/about/ourmembers.md
+++ b/about/ourmembers.md
@@ -91,8 +91,61 @@ aside {
 >1. 
 
 ## Top 100 Submitters
+1. Brookhaven National Laboratory (USA)
+1. Carnegie Mellon University (USA)
+1. Columbia University (USA)
+1. CSIC - Spanish National Research Council (Spain)
+1. Fermilab (USA)
+1. Harvard University (USA)
+1. KTH Royal Institute of Technology  (Sweden)
+1. New York University (USA)
+1. Princeton University (USA)
+1. SISSA (Scuola Internazionale Superiore di Studi Avanzati) (Italy)
+1. Stanford University, and SLAC (USA)
+1. Texas A&M University (USA)
+1. Tsinghua University  (China)
+1. University of Amsterdam  (Netherlands)
+1. Arizona State University (USA)
+1. University of British Columbia (Canada)
+1. University of Toronto (Canada)
+1. University of Waterloo  (Canada)
+1. Yale University (USA)
 
 ## Frequent Submitters
+1. Argonne National Lab (USA)
+1. Boston University (USA)
+1. George Mason University (USA)
+1. Ghent University Libraries (Belgium)
+1. Hebrew University of Jerusalem (Israel)
+1. Iowa State University
+1. King Abdullah University of Science and Technology (KAUST) (Saudi Arabia)
+1. Leiden University (Leiden Institute of Physics) (Netherlands)
+1. McGill University (Canada)
+1. McMaster University (Canada)
+1. National Taiwan University (Taiwan)
+1. Perimeter Institute for Theoretical Physics  (Canada)
+1. Rice University (USA)
+1. Simon Fraser University (Canada)
+1. Syracuse University
+1. Tufts University (USA)
+1. Universität Basel (Switzerland)
+1. Universitetet Oslo (Norway)
+1. University at Buffalo (USA)
+1. University of Alberta (Canada)
+1. University of Cape Town (South Africa)
+1. University of Florida (USA)
+1. University of Groningen  (Netherlands)
+1. University of Helsinki (Finland)
+1. University of Innsbruck (Austria)
+1. Kansas State University (USA)
+1. University of North Carolina (USA)
+1. University of Notre Dame (USA)
+1. University of Oregon (USA)
+1. University of Rochester (USA)
+1. University of Vienna  (Austria)
+1. University of Virginia (USA)
+1. Vrije Universiteit Brussel (Belgium)
+1. Western University (Canada)
 
 ## Regular Submitters & Community Contributors
 
@@ -106,36 +159,25 @@ aside {
 
 ## Tier 1
 
-1. Columbia University (USA)
 1. DESY (HGF - Helmholtz Association, German Research Centers) (Germany) _arXiv-DH and HGF_
 1. Ecole Polytechnique Fédérale de Lausanne (EPFL)  (Switzerland)
 1. ETH Zurich (Switzerland)
-1. Harvard University (USA)
 1. Kyoto University  (Japan) _NII Japan Consortium_
 1. Los Alamos National Laboratory  (USA)
 1. Max Planck Digital Library (Germany)
-1. New York University (USA)
 1. University of Pennsylvania (USA)
-1. Princeton University (USA)
-1. SISSA (Scuola Internazionale Superiore di Studi Avanzati) (Italy)
-1. Stanford University, and SLAC (USA)
 1. University College London  (UK) _JISC_
-1. University of Amsterdam  (Netherlands)
 1. University of California, Berkeley (USA) _CDL_
 1. University of Illinois at Urbana-Champaign  (USA) _BTAA_
 1. University of Oxford  (UK) _JISC_
 1. University of Sydney (Australia)
 1. University of Tokyo  (Japan) _NII Japan Consortium_
-1. University of Waterloo  (Canada)
 
 ## Tier 2
 
-1. Carnegie Mellon University (USA)
 1. The Chinese University of Hong Kong (Hong Kong)
 1. Durham University (UK) _JISC_
 1. Karlsruher Institut für Technologie (Germany) _arXiv-DH and HGF_
-1. National Taiwan University (Taiwan)
-1. Perimeter Institute for Theoretical Physics  (Canada)
 1. Rutgers University (USA) _BTAA_
 1. Stony Brook University  (USA)
 1. Universität Bonn  (Germany) _arXiv-DH and HGF_
@@ -146,13 +188,10 @@ aside {
 1. University of Maryland (USA) _BTAA_
 1. University of Minnesota (USA) _BTAA_
 1. University of Texas at Austin (USA)
-1. University of Toronto (Canada)
 1. University of Wisconsin, Madison (USA) _BTAA_
-1. Yale University (USA)
 
 ## Tier 3
 
-1. Boston University (USA)
 1. Chalmers University of Technology  (Sweden)
 1. Commissariat à l'Énergie Atomique (CEA) (France) _CCSD_
 1. Delft University of Technology  (Netherlands)
@@ -160,7 +199,6 @@ aside {
 1. Institute for Advanced Study (USA)
 1. International Centre for Theoretical Physics (ICTP) (Italy)
 1. Italian Institute for Astrophysics (INAF) (Italy)
-1. KTH Royal Institute of Technology  (Sweden)
 1. KU Leuven (Belgium)
 1. Nagoya University  (Japan) _NII Japan Consortium_
 1. Northwestern University (USA) _BTAA_
@@ -177,38 +215,28 @@ aside {
 1. Universität Hamburg  (Germany) _arXiv-DH and HGF_
 1. Universität Mainz (Germany) _arXiv-DH and HGF_
 1. University of Bristol (UK) _JISC_
-1. University of British Columbia (Canada)
 1. University of California, Davis (USA) _CDL_
 1. University of California, San Diego (USA) _CDL_
 1. University of Chicago (USA) _BTAA_
 1. University of Colorado (USA)
-1. University of Florida (USA)
-1. University of Groningen  (Netherlands)
 1. University of Manchester (UK) _JISC_
 1. University of Massachusetts (USA)
 1. University of Michigan  (USA) _BTAA_
 1. University of Southern California (USA)
 1. University of Technology Sydney (Australia)
-1. University of Vienna  (Austria)
 1. University of Warwick (UK) _JISC_
 1. University of Washington Libraries (USA)
 1. University of Zurich, Institute of Theoretical Physics  (Switzerland)
 1. UPMC (Universite Pierre and Marie Curie) (France) _CCSD_
 1. Uppsala University (Sweden)
-1. Vrije Universiteit Brussel (Belgium)
 
 ## Tier 4
 
-1. Brookhaven National Laboratory (USA)
-1. CSIC - Spanish National Research Council (Spain)
 1. Freie Universität Berlin  (Germany) _arXiv-DH and HGF_
-1. Hebrew University of Jerusalem (Israel)
 1. Humboldt-Universität zu Berlin  (Germany) _arXiv-DH and HGF_
 1. Johns Hopkins University (USA)
 1. Joint Institute for Nuclear Research (JINR)  (Russia)
 1. KEK High Energy Accelerator Research Organization (Japan) _NII Japan Consortium_
-1. Leiden University (Leiden Institute of Physics) (Netherlands)
-1. McGill University (Canada)
 1. Monash University (Australia)
 1. Penn State University (USA) _BTAA_
 1. Physical Research Laboratory (2016-2020 membership sponsored by Anurag Acharya) (India)
@@ -217,7 +245,6 @@ aside {
 1. Texas A&M University  (USA)
 1. Tokyo Institute of Technology Library (Japan) _NII Japan Consortium_
 1. TU Wien (Austria)
-1. Universität Basel (Switzerland)
 1. Universität Erlangen-Nürnberg  (Germany) _arXiv-DH and HGF_
 1. Universität Frankfurt am Main  (Germany) _arXiv-DH and HGF_
 1. Universität Hannover  (Germany) _arXiv-DH and HGF_
@@ -227,13 +254,9 @@ aside {
 1. Universität-Münster (Germany) _arXiv-DH and HGF_
 1. Université de Montréal (Canada)
 1. Université Paris-Sud (France) _CCSD_
-1. University of Alberta (Canada)
 1. University of Bern  (Switzerland)
 1. University of California, Santa Cruz (USA) _CDL_
-1. University of Helsinki (Finland)
-1. University of Innsbruck (Austria)
 1. University of Melbourne (Australia)
-1. University of North Carolina (USA)
 1. University of Sheffield (UK) _JISC_
 1. University of Southampton (UK) _JISC_
 1. University of Sussex (UK) _JISC_
@@ -242,18 +265,14 @@ aside {
 ## Tier 5
 
 1. Aalto University (Finland)
-1. Argonne National Lab (USA)
-1. Arizona State University (USA)
 1. Australian National University (Australia)
 1. Duke University (USA)
 1. Forschungszentrum Julich (Germany) _arXiv-DH and HGF_
-1. Ghent University Libraries (Belgium)
 1. Keio University (Japan) _NII Japan Consortium_
 1. King's College London (UK) _JISC_
 1. Kyushu University (Japan) _NII Japan Consortium_
 1. Lund University Libraries, Lund University (Sweden)
 1. National Astronomical Observatory of Japan (Japan) _NII Japan Consortium_
-1. Simon Fraser University (Canada)
 1. Tata Institute of Fundamental Research (2016-2020 membership sponsored by Anurag Acharya) (India)
 1. Tokyo University of Science (Japan) _NII Japan Consortium_
 1. Universität Bielefeld  (Germany) _arXiv-DH and HGF_
@@ -263,13 +282,10 @@ aside {
 1. Universität Tübingen  (Germany) _arXiv-DH and HGF_
 1. Universität Ulm (Germany) _arXiv-DH and HGF_
 1. Universität Würzburg (Germany) _arXiv-DH and HGF_
-1. Universitetet Oslo (Norway)
-1. University at Buffalo (USA)
 1. University of Adelaide (Australia)
 1. University of Glasgow (UK) _JISC_
 1. University of New South Wales, Sydney (Australia)
 1. University of Queensland (Australia)
-1. University of Rochester (USA)
 1. University of Utah (USA)
 1. Waseda University (Japan) _NII Japan Consortium_
 1. Washington University in St. Louis  (USA)
@@ -284,9 +300,7 @@ aside {
 1. Central European University (Hungary)
 1. Dublin Institute for Advanced Studies (Ireland)
 1. European Southern Observatory (Germany)
-1. Fermilab (USA)
 1. Free University of Amsterdam (Netherlands)
-1. George Mason University (USA)
 1. George Washington University (USA)
 1. Georgetown University  (USA)
 1. Harish-Chandra Research Institute (2016-2020 membership sponsored by Anurag Acharya) (India)
@@ -296,13 +310,10 @@ aside {
 1. Institute of Math Sciences (India)
 1. Institute of Physics of the Czech Academy of Sciences (Czech Republic)
 1. IST Austria (Austria)
-1. Kansas State University (USA)
-1. King Abdullah University of Science and Technology (KAUST) (Saudi Arabia)
 1. Kobe University (Japan) _NII Japan Consortium_
 1. Lawrence Berkeley National Laboratory (USA) _CDL_
 1. Lehigh University (USA)
 1. Macquarie University (Australia)
-1. McMaster University (Canada)
 1. Michigan State University (USA) _BTAA_
 1. Niels Bohr Institute (Denmark)
 1. Nikhef (Netherlands)
@@ -311,13 +322,9 @@ aside {
 1. Queens University (Canada)
 1. Raman Research Institute (India)
 1. Research Centre for Astronomy and Earth Sciences (Hungary)
-1. Rice University (USA)
-1. Syracuse University
 1. Technion - Israel Institute of Technology  (Israel)
 1. Technische Universität Dortmund (Germany) _arXiv-DH and HGF_
 1. TRIUMF (Canada)
-1. Tsinghua University  (China)
-1. Tufts University (USA)
 1. Universität Graz (Austria)
 1. Universität Konstanz (Germany) _arXiv-DH and HGF_
 1. Universität Mannheim (Germany) _arXiv-DH and HGF_
@@ -331,7 +338,6 @@ aside {
 1. University of California, Merced (USA) _CDL_
 1. University of California, Riverside  (USA) _CDL_
 1. University of California, San Francisco (USA) _CDL_
-1. University of Cape Town (South Africa)
 1. University of Cardiff (UK) _JISC_
 1. University of Central Oklahoma (USA)
 1. University of Graz (Austria)
@@ -343,12 +349,9 @@ aside {
 1. University of Nebraska (USA) _BTAA_
 1. University of New Hampshire (USA)
 1. University of North Texas (USA)
-1. University of Notre Dame (USA)
 1. University of Nottingham (UK) _JISC_
-1. University of Oregon (USA)
 1. University of Pittsburgh (USA)
 1. University of Tsukuba (Japan) _NII Japan Consortium_
-1. University of Virginia (USA)
 1. University of Western Australia (Australia)
 1. University of Witwatersrand (South Africa)
 1. University of Wollongong (Australia)
@@ -357,7 +360,7 @@ aside {
 1. Villanova (USA)
 1. Washington State University (USA)
 1. Weizmann Institute of Science (Israel)
-1. Western University (Canada)
+
 
 
 

--- a/about/ourmembers.md
+++ b/about/ourmembers.md
@@ -88,16 +88,22 @@ aside {
 
 ## Consortia
 >1. arXiv DH and HGF Consortium (Germany)
->1. 
+>1. Centre pour la Communication Scientifique Directe (France)
+>1. NII Japan Consortium (Japan)
 
 ## Top 100 Submitters
+1. Australian National University (Australia)
 1. Brookhaven National Laboratory (USA)
 1. Carnegie Mellon University (USA)
 1. Columbia University (USA)
 1. CSIC - Spanish National Research Council (Spain)
+1. Duke University (USA)
+1. ETH Zurich (Switzerland)
 1. Fermilab (USA)
 1. Harvard University (USA)
 1. KTH Royal Institute of Technology  (Sweden)
+1. Los Alamos National Laboratory  (USA)
+1. Max Planck Digital Library (Germany)
 1. New York University (USA)
 1. Princeton University (USA)
 1. SISSA (Scuola Internazionale Superiore di Studi Avanzati) (Italy)
@@ -107,6 +113,9 @@ aside {
 1. University of Amsterdam  (Netherlands)
 1. Arizona State University (USA)
 1. University of British Columbia (Canada)
+1. University of Colorado (USA)
+1. University of Pennsylvania (USA)
+1. University of Sydney (Australia)
 1. University of Toronto (Canada)
 1. University of Waterloo  (Canada)
 1. Yale University (USA)
@@ -114,21 +123,27 @@ aside {
 ## Frequent Submitters
 1. Argonne National Lab (USA)
 1. Boston University (USA)
+1. Brown University (USA)
 1. George Mason University (USA)
 1. Ghent University Libraries (Belgium)
 1. Hebrew University of Jerusalem (Israel)
 1. Iowa State University
+1. Kansas State University (USA)
 1. King Abdullah University of Science and Technology (KAUST) (Saudi Arabia)
 1. Leiden University (Leiden Institute of Physics) (Netherlands)
 1. McGill University (Canada)
 1. McMaster University (Canada)
+1. Monash University (Australia)
 1. National Taiwan University (Taiwan)
 1. Perimeter Institute for Theoretical Physics  (Canada)
+1. Queensland University of Technology (Australia)
 1. Rice University (USA)
 1. Simon Fraser University (Canada)
+1. Stony Brook University (USA)
 1. Syracuse University
 1. Tufts University (USA)
 1. Universität Basel (Switzerland)
+1. Université de Montréal (Canada)
 1. Universitetet Oslo (Norway)
 1. University at Buffalo (USA)
 1. University of Alberta (Canada)
@@ -137,18 +152,53 @@ aside {
 1. University of Groningen  (Netherlands)
 1. University of Helsinki (Finland)
 1. University of Innsbruck (Austria)
-1. Kansas State University (USA)
+1. University of Adelaide (Australia)
+1. University of Massachusetts (USA)
+1. University of Melbourne (Australia)
 1. University of North Carolina (USA)
 1. University of Notre Dame (USA)
 1. University of Oregon (USA)
+1. University of Queensland (Australia)
 1. University of Rochester (USA)
 1. University of Vienna  (Austria)
 1. University of Virginia (USA)
+1. University of Western Australia (Australia)
+1. Uppsala University (Sweden)
 1. Vrije Universiteit Brussel (Belgium)
+1. Weizmann Institute of Science (Israel)
 1. Western University (Canada)
 
 ## Regular Submitters & Community Contributors
-
+1. Boston College (USA)
+1. Central European University (Hungary)
+1. European Southern Observatory (Germany)
+1. Georgetown University (USA)
+1. Institute for Advanced Study (USA)
+1. Institute of Math Sciences (India)
+1. Institute of Physics of the Czech Academy of Sciences (Czech Republic)
+1. IST Austria (Austria)
+1. Lehigh University (USA)
+1. Macquarie University (Australia)
+1. National Library of Sweden (Sweden)
+1. Niels Bohr Institute (Denmark)
+1. Nikhef (Netherlands)
+1. Oregon State University (USA)
+1. Queens University (Canada)
+1. Raman Research Institute (India)
+1. Research Centre for Astronomy and Earth Sciences (Hungary)
+1. Technion - Israel Institute of Technology  (Israel)
+1. Universität Graz (Austria)
+1. University of Arkansas (USA)
+1. University of Auckland (New Zealand)
+1. University of Central Oklahoma (USA)
+1. University of Georgia (USA)
+1. University of New Hampshire (USA)
+1. University of North Texas (USA)
+1. University of Wollongong (Australia)
+1. Victoria University of Wellington (New Zealand)
+1. Villanova (USA)
+1. Virginia Tech (USA)
+1. Washington State University (USA)
 
 
 
@@ -161,16 +211,11 @@ aside {
 
 1. DESY (HGF - Helmholtz Association, German Research Centers) (Germany) _arXiv-DH and HGF_
 1. Ecole Polytechnique Fédérale de Lausanne (EPFL)  (Switzerland)
-1. ETH Zurich (Switzerland)
 1. Kyoto University  (Japan) _NII Japan Consortium_
-1. Los Alamos National Laboratory  (USA)
-1. Max Planck Digital Library (Germany)
-1. University of Pennsylvania (USA)
 1. University College London  (UK) _JISC_
 1. University of California, Berkeley (USA) _CDL_
 1. University of Illinois at Urbana-Champaign  (USA) _BTAA_
 1. University of Oxford  (UK) _JISC_
-1. University of Sydney (Australia)
 1. University of Tokyo  (Japan) _NII Japan Consortium_
 
 ## Tier 2
@@ -179,7 +224,6 @@ aside {
 1. Durham University (UK) _JISC_
 1. Karlsruher Institut für Technologie (Germany) _arXiv-DH and HGF_
 1. Rutgers University (USA) _BTAA_
-1. Stony Brook University  (USA)
 1. Universität Bonn  (Germany) _arXiv-DH and HGF_
 1. Universität Heidelberg (Germany) _arXiv-DH and HGF_
 1. University of California, Los Angeles (USA) _CDL_
@@ -196,7 +240,6 @@ aside {
 1. Commissariat à l'Énergie Atomique (CEA) (France) _CCSD_
 1. Delft University of Technology  (Netherlands)
 1. Indiana University (USA) _BTAA_
-1. Institute for Advanced Study (USA)
 1. International Centre for Theoretical Physics (ICTP) (Italy)
 1. Italian Institute for Astrophysics (INAF) (Italy)
 1. KU Leuven (Belgium)
@@ -204,7 +247,6 @@ aside {
 1. Northwestern University (USA) _BTAA_
 1. Osaka University (Japan) _NII Japan Consortium_
 1. Purdue University (USA) _BTAA_
-1. Queensland University of Technology (Australia)
 1. RWTH Aachen  (Germany) _arXiv-DH and HGF_
 1. Stockholm University (Sweden)
 1. Technische Universität Berlin  (Germany) _arXiv-DH and HGF_
@@ -218,9 +260,7 @@ aside {
 1. University of California, Davis (USA) _CDL_
 1. University of California, San Diego (USA) _CDL_
 1. University of Chicago (USA) _BTAA_
-1. University of Colorado (USA)
 1. University of Manchester (UK) _JISC_
-1. University of Massachusetts (USA)
 1. University of Michigan  (USA) _BTAA_
 1. University of Southern California (USA)
 1. University of Technology Sydney (Australia)
@@ -228,7 +268,6 @@ aside {
 1. University of Washington Libraries (USA)
 1. University of Zurich, Institute of Theoretical Physics  (Switzerland)
 1. UPMC (Universite Pierre and Marie Curie) (France) _CCSD_
-1. Uppsala University (Sweden)
 
 ## Tier 4
 
@@ -237,7 +276,6 @@ aside {
 1. Johns Hopkins University (USA)
 1. Joint Institute for Nuclear Research (JINR)  (Russia)
 1. KEK High Energy Accelerator Research Organization (Japan) _NII Japan Consortium_
-1. Monash University (Australia)
 1. Penn State University (USA) _BTAA_
 1. Physical Research Laboratory (2016-2020 membership sponsored by Anurag Acharya) (India)
 1. Radboud University (Netherlands)
@@ -252,21 +290,16 @@ aside {
 1. Universität Stuttgart (Germany) _arXiv-DH and HGF_
 1. Universität zu Köln  (Germany) _arXiv-DH and HGF_
 1. Universität-Münster (Germany) _arXiv-DH and HGF_
-1. Université de Montréal (Canada)
 1. Université Paris-Sud (France) _CCSD_
 1. University of Bern  (Switzerland)
 1. University of California, Santa Cruz (USA) _CDL_
-1. University of Melbourne (Australia)
 1. University of Sheffield (UK) _JISC_
 1. University of Southampton (UK) _JISC_
 1. University of Sussex (UK) _JISC_
-1. Virginia Tech (USA)
 
 ## Tier 5
 
 1. Aalto University (Finland)
-1. Australian National University (Australia)
-1. Duke University (USA)
 1. Forschungszentrum Julich (Germany) _arXiv-DH and HGF_
 1. Keio University (Japan) _NII Japan Consortium_
 1. King's College London (UK) _JISC_
@@ -282,10 +315,8 @@ aside {
 1. Universität Tübingen  (Germany) _arXiv-DH and HGF_
 1. Universität Ulm (Germany) _arXiv-DH and HGF_
 1. Universität Würzburg (Germany) _arXiv-DH and HGF_
-1. University of Adelaide (Australia)
 1. University of Glasgow (UK) _JISC_
 1. University of New South Wales, Sydney (Australia)
-1. University of Queensland (Australia)
 1. University of Utah (USA)
 1. Waseda University (Japan) _NII Japan Consortium_
 1. Washington University in St. Louis  (USA)
@@ -294,72 +325,44 @@ aside {
 
 1. Ames Laboratory (USA)
 1. Bibliothèque de l'Observatoire de Paris (OBSPM) (France) _CCSD_
-1. Boston College (USA)
-1. Brown University (USA)
 1. Case Western Reserve University (USA)
-1. Central European University (Hungary)
 1. Dublin Institute for Advanced Studies (Ireland)
-1. European Southern Observatory (Germany)
 1. Free University of Amsterdam (Netherlands)
 1. George Washington University (USA)
-1. Georgetown University  (USA)
 1. Harish-Chandra Research Institute (2016-2020 membership sponsored by Anurag Acharya) (India)
 1. Hiroshima University (Japan) _NII Japan Consortium_
 1. Hokkaido University  (Japan) _NII Japan Consortium_
 1. IHEP, National Science Library, CAS (China)
-1. Institute of Math Sciences (India)
-1. Institute of Physics of the Czech Academy of Sciences (Czech Republic)
-1. IST Austria (Austria)
 1. Kobe University (Japan) _NII Japan Consortium_
 1. Lawrence Berkeley National Laboratory (USA) _CDL_
-1. Lehigh University (USA)
-1. Macquarie University (Australia)
 1. Michigan State University (USA) _BTAA_
-1. Niels Bohr Institute (Denmark)
-1. Nikhef (Netherlands)
 1. Ohio State University (USA) _BTAA_
-1. Oregon State (USA)
-1. Queens University (Canada)
-1. Raman Research Institute (India)
-1. Research Centre for Astronomy and Earth Sciences (Hungary)
-1. Technion - Israel Institute of Technology  (Israel)
 1. Technische Universität Dortmund (Germany) _arXiv-DH and HGF_
 1. TRIUMF (Canada)
-1. Universität Graz (Austria)
 1. Universität Konstanz (Germany) _arXiv-DH and HGF_
 1. Universität Mannheim (Germany) _arXiv-DH and HGF_
 1. Université de Grenoble Alpes (France) _CCSD_
 1. Université de Rennes 1 (France) _CCSD_
 1. University of Arizona (USA)
-1. University of Arkansas (USA)
-1. University of Auckland (New Zealand)
 1. University of Birmingham (UK) _JISC_
 1. University of California, Irvine (USA) _CDL_
 1. University of California, Merced (USA) _CDL_
 1. University of California, Riverside  (USA) _CDL_
 1. University of California, San Francisco (USA) _CDL_
 1. University of Cardiff (UK) _JISC_
-1. University of Central Oklahoma (USA)
 1. University of Graz (Austria)
 1. University of Geneva (Switzerland)
-1. University of Georgia (USA)
 1. University of Hawaii (USA)
 1. University of Iowa (USA) _BTAA_
 1. University of Kansas (USA)
 1. University of Nebraska (USA) _BTAA_
-1. University of New Hampshire (USA)
-1. University of North Texas (USA)
 1. University of Nottingham (UK) _JISC_
 1. University of Pittsburgh (USA)
 1. University of Tsukuba (Japan) _NII Japan Consortium_
-1. University of Western Australia (Australia)
 1. University of Witwatersrand (South Africa)
-1. University of Wollongong (Australia)
 1. University of York (UK) _JISC_
 1. Utrecht University (Netherlands)
-1. Villanova (USA)
-1. Washington State University (USA)
-1. Weizmann Institute of Science (Israel)
+
 
 
 

--- a/about/ourmembers.md
+++ b/about/ourmembers.md
@@ -76,13 +76,32 @@ aside {
 }
 </style>
 
-## Platinum Members
+## Champion Consortia
+>1. Big Ten Academic Alliance (USA)
+>1. California Digital Libraries (USA)
 
+## Champion Members
 >1. California Institute of Technology (USA)
 >1. CERN-European Organization for Nuclear Research (Switzerland)
 >1. Georgia Institute of Technology (USA)
->1. Imperial College London (UK) _JISC_
 >1. Massachusetts Institute of Technology (MIT) (USA)
+
+## Consortia
+>1. arXiv DH and HGF Consortium (Germany)
+>1. 
+
+## Top 100 Submitters
+
+## Frequent Submitters
+
+## Regular Submitters & Community Contributors
+
+
+
+
+## Platinum Members
+
+>1. Imperial College London (UK) _JISC_
 >1. University of Cambridge (UK) _JISC_
 
 ## Tier 1

--- a/about/ourmembers.md
+++ b/about/ourmembers.md
@@ -80,16 +80,16 @@ aside {
 >1. Big Ten Academic Alliance (USA)
 >1. California Digital Libraries (USA)
 
+## Consortia
+>1. arXiv DH and HGF Consortium (Germany)
+>1. Centre pour la Communication Scientifique Directe (France)
+>1. NII Japan Consortium (Japan)
+
 ## Champion Members
 >1. California Institute of Technology (USA)
 >1. CERN-European Organization for Nuclear Research (Switzerland)
 >1. Georgia Institute of Technology (USA)
 >1. Massachusetts Institute of Technology (MIT) (USA)
-
-## Consortia
->1. arXiv DH and HGF Consortium (Germany)
->1. Centre pour la Communication Scientifique Directe (France)
->1. NII Japan Consortium (Japan)
 
 ## Top 100 Submitters
 1. Arizona State University (USA)
@@ -105,6 +105,7 @@ aside {
 1. Indiana University (USA) _BTAA_
 1. Karlsruher Institut für Technologie (Germany) _arXiv-DH and HGF_
 1. KTH Royal Institute of Technology  (Sweden)
+1. Kyoto University  (Japan) _NII Japan Consortium_
 1. Lawrence Berkeley National Laboratory (USA) _CDL_
 1. Los Alamos National Laboratory  (USA)
 1. Max Planck Digital Library (Germany)
@@ -138,6 +139,7 @@ aside {
 1. University of Minnesota (USA) _BTAA_
 1. University of Pennsylvania (USA)
 1. University of Sydney (Australia)
+1. University of Tokyo  (Japan) _NII Japan Consortium_
 1. University of Toronto (Canada)
 1. University of Waterloo  (Canada)
 1. University of Wisconsin, Madison (USA) _BTAA_
@@ -154,14 +156,23 @@ aside {
 1. George Mason University (USA)
 1. Ghent University Libraries (Belgium)
 1. Hebrew University of Jerusalem (Israel)
+1. Hiroshima University (Japan) _NII Japan Consortium_
+1. Hokkaido University  (Japan) _NII Japan Consortium_
 1. Iowa State University (USA)
 1. Kansas State University (USA)
+1. Keio University (Japan) _NII Japan Consortium_
+1. KEK High Energy Accelerator Research Organization (Japan) _NII Japan Consortium_
 1. King Abdullah University of Science and Technology (KAUST) (Saudi Arabia)
+1. Kobe University (Japan) _NII Japan Consortium_
+1. Kyushu University (Japan) _NII Japan Consortium_
 1. Leiden University (Leiden Institute of Physics) (Netherlands)
 1. McGill University (Canada)
 1. McMaster University (Canada)
 1. Monash University (Australia)
+1. Nagoya University  (Japan) _NII Japan Consortium_
+1. National Astronomical Observatory of Japan (Japan) _NII Japan Consortium_
 1. National Taiwan University (Taiwan)
+1. Osaka University (Japan) _NII Japan Consortium_
 1. Perimeter Institute for Theoretical Physics  (Canada)
 1. Queensland University of Technology (Australia)
 1. Rice University (USA)
@@ -171,6 +182,8 @@ aside {
 1. Technische Universität Berlin  (Germany) _arXiv-DH and HGF_
 1. Technische Universität Darmstadt (Germany) _arXiv-DH and HGF_
 1. Technische Universität Dortmund (Germany) _arXiv-DH and HGF_
+1. Tohoku University (Japan) _NII Japan Consortium_
+1. Tokyo Institute of Technology Library (Japan) _NII Japan Consortium_
 1. Tufts University (USA)
 1. Universität Basel (Switzerland)
 1. Universität Bielefeld  (Germany) _arXiv-DH and HGF_
@@ -211,11 +224,14 @@ aside {
 1. University of Oregon (USA)
 1. University of Queensland (Australia)
 1. University of Rochester (USA)
+1. University of Technology Sydney (Australia)
+1. University of Tsukuba (Japan) _NII Japan Consortium_
 1. University of Vienna  (Austria)
 1. University of Virginia (USA)
 1. University of Western Australia (Australia)
 1. Uppsala University (Sweden)
 1. Vrije Universiteit Brussel (Belgium)
+1. Waseda University (Japan) _NII Japan Consortium_
 1. Weizmann Institute of Science (Israel)
 1. Western University (Canada)
 
@@ -238,6 +254,7 @@ aside {
 1. Raman Research Institute (India)
 1. Research Centre for Astronomy and Earth Sciences (Hungary)
 1. Technion - Israel Institute of Technology  (Israel)
+1. Tokyo University of Science (Japan) _NII Japan Consortium_
 1. Universität Graz (Austria)
 1. Universität Konstanz (Germany) _arXiv-DH and HGF_
 1. Universität Mannheim (Germany) _arXiv-DH and HGF_
@@ -265,12 +282,9 @@ aside {
 
 ## Tier 1
 
-
 1. Ecole Polytechnique Fédérale de Lausanne (EPFL)  (Switzerland)
-1. Kyoto University  (Japan) _NII Japan Consortium_
 1. University College London  (UK) _JISC_
 1. University of Oxford  (UK) _JISC_
-1. University of Tokyo  (Japan) _NII Japan Consortium_
 
 ## Tier 2
 
@@ -287,18 +301,12 @@ aside {
 1. International Centre for Theoretical Physics (ICTP) (Italy)
 1. Italian Institute for Astrophysics (INAF) (Italy)
 1. KU Leuven (Belgium)
-1. Nagoya University  (Japan) _NII Japan Consortium_
-1. Osaka University (Japan) _NII Japan Consortium_
 1. Stockholm University (Sweden)
-
-
-1. Tohoku University (Japan) _NII Japan Consortium_
-
 
 1. University of Bristol (UK) _JISC_
 1. University of Manchester (UK) _JISC_
 1. University of Southern California (USA)
-1. University of Technology Sydney (Australia)
+
 1. University of Warwick (UK) _JISC_
 1. University of Washington Libraries (USA)
 1. University of Zurich, Institute of Theoretical Physics  (Switzerland)
@@ -309,12 +317,11 @@ aside {
 
 1. Johns Hopkins University (USA)
 1. Joint Institute for Nuclear Research (JINR)  (Russia)
-1. KEK High Energy Accelerator Research Organization (Japan) _NII Japan Consortium_
 1. Physical Research Laboratory (2016-2020 membership sponsored by Anurag Acharya) (India)
 1. Radboud University (Netherlands)
 1. Tel Aviv University (Israel)
 1. Texas A&M University  (USA)
-1. Tokyo Institute of Technology Library (Japan) _NII Japan Consortium_
+
 1. TU Wien (Austria)
 
 1. Université Paris-Sud (France) _CCSD_
@@ -326,18 +333,13 @@ aside {
 ## Tier 5
 
 1. Aalto University (Finland)
-1. Keio University (Japan) _NII Japan Consortium_
 1. King's College London (UK) _JISC_
-1. Kyushu University (Japan) _NII Japan Consortium_
 1. Lund University Libraries, Lund University (Sweden)
-1. National Astronomical Observatory of Japan (Japan) _NII Japan Consortium_
 1. Tata Institute of Fundamental Research (2016-2020 membership sponsored by Anurag Acharya) (India)
-1. Tokyo University of Science (Japan) _NII Japan Consortium_
 
 1. University of Glasgow (UK) _JISC_
 1. University of New South Wales, Sydney (Australia)
 1. University of Utah (USA)
-1. Waseda University (Japan) _NII Japan Consortium_
 1. Washington University in St. Louis  (USA)
 
 ## Tier 6
@@ -348,10 +350,8 @@ aside {
 1. Free University of Amsterdam (Netherlands)
 1. George Washington University (USA)
 1. Harish-Chandra Research Institute (2016-2020 membership sponsored by Anurag Acharya) (India)
-1. Hiroshima University (Japan) _NII Japan Consortium_
-1. Hokkaido University  (Japan) _NII Japan Consortium_
+
 1. IHEP, National Science Library, CAS (China)
-1. Kobe University (Japan) _NII Japan Consortium_
 1. TRIUMF (Canada)
 
 1. Université de Grenoble Alpes (France) _CCSD_
@@ -365,7 +365,6 @@ aside {
 1. University of Kansas (USA)
 1. University of Nottingham (UK) _JISC_
 1. University of Pittsburgh (USA)
-1. University of Tsukuba (Japan) _NII Japan Consortium_
 1. University of Witwatersrand (South Africa)
 1. University of York (UK) _JISC_
 1. Utrecht University (Netherlands)

--- a/about/people/scientific_ad_board.md
+++ b/about/people/scientific_ad_board.md
@@ -63,12 +63,11 @@ Professor of Computer Science, Cornell University (ex
 Professor, University of Minnesota
 > -   ### Tara Holm
 Professor of Mathematics, Cornell University
+> -   ### Eiichiro Komatsu
+Director of the Department of Physical Cosmology, Max-Planck-Institut für Astrophysik, Germany
 > -   ### Greg Kuperberg
 Professor of Mathematics, University of California,
     Davis (ex officio, as chair of Mathematics Advisory Committee)
-> -   ### David Morrison
-Professor of Mathematics and Physics,
-    University of California, Santa Barbara
 > -   ### Sumati Surya
 Professor, Raman Research Institute
 > -   ### Licia Verde (**Chair**)

--- a/about/people/scientific_ad_board.md
+++ b/about/people/scientific_ad_board.md
@@ -100,6 +100,7 @@ The current Board, and Cornell University, would like to express
 appreciation to the following former members of the Scientific Advisory
 Board, for their contributions to arXiv's governance and success.
 
+-   David Morrison, University of California, Santa Barbara
 -   Robert Seiringer, Institute of Science and Technology Austria
 -   Eberhard Bodenschatz, Max Planck Institut für Dynamik und Selbstorganisation, Göttingen \| Cornell University
 -   Gregory Gabadadze, New York University \| Simons Foundation

--- a/about/people/scientific_ad_board.md
+++ b/about/people/scientific_ad_board.md
@@ -70,11 +70,11 @@ Professor of Mathematics, University of California,
     Davis (ex officio, as chair of Mathematics Advisory Committee)
 > -   ### Sumati Surya
 Professor, Raman Research Institute
-> -   ### Licia Verde (**Chair**)
+> -   ### Licia Verde 
 ICREA Research Professor, Universitat de Barcelona
 > -   ### Larry Wassermann
 Professor, Carnegie Mellon University (chair of Statistics Advisory Committee)
-> -   ### Ralph Wijers
+> -   ### Ralph Wijers (**Chair**)
 Professor, University of Amsterdam (ex officio, as chair of Physics Advisory Committee)
 
 <span id="advisory_committees"></span>

--- a/about/supporters.md
+++ b/about/supporters.md
@@ -86,6 +86,7 @@ aside {
 >1. Allen Institute for Artificial Intelligence (USA)
 >1. Computer Vision Foundation (USA)
 >1. Google, Inc (USA)
+>1. Facebook AI (USA)
 
 ## Silver Affiliates
 
@@ -97,9 +98,6 @@ aside {
 >1. Institute of Physics Publishing (UK)
 >1. NWO Dutch Reseach Council (Netherlands)
 >1. Deutsche Physikalische Gesellschaft (Germany)
-
-## Silver Sponsors
->1. Facebook AI (USA)
 
 
 #


### PR DESCRIPTION
This PR updates: 

- /ourmembers with the institutions that have officially committed to supporting arXiv in 2022. This list is to be updated quarterly
- the SAB page with board changes for 2022. This list is to be updated at least yearly, or as needed
- /supporters with the nonprofits and companies that have supported arXiv in the past 12 months. This list is to be updated at least yearly, or as needed
