### PR TITLE
Attempt to add expectations for filenames to help/submit_tex and help/faq/mistakes

### DIFF
--- a/help/faq/mistakes.md
+++ b/help/faq/mistakes.md
@@ -14,6 +14,7 @@ Look through these common mistakes if your TeX/LaTeX submission failed:
 
   - [Absolute filenames](#abs_filenames)
   - [Upper-case vs Lower-case filenames](#case_filenames)
+  - [Spaces and other inappropriate characters in filenames](#space_filesnames)
   - [Missing style/macro files](#missing_macro)
   - [Last minute untested changes](#untested)
   - [User intervention](#intervention)
@@ -92,6 +93,10 @@ Look through these common mistakes if your TeX/LaTeX submission failed:
     because filenames are case-sensitive on our system.
     
       
+  - <span id="space_filesnames"></span>**Spaces and other inappropriate characters in filenames**
+    Do not use spaces in filenames, in either your figure inclusion commands or directory names. Do not use common filesystem delimiters in file names (*i.e* `/`, `\`, `:`, etc.). Certain symbols such as the ampersand (`&`) can cause problems as well, and should be avoided. 
+
+    During file upload these examples will be programmatically converted to an underscore character (the `_` character). 
 
   - <span id="missing_macro"></span>**Missing style/macro files**  
     Some authors write their own style/macro files (or modify standard

--- a/help/faq/mistakes.md
+++ b/help/faq/mistakes.md
@@ -14,7 +14,7 @@ Look through these common mistakes if your TeX/LaTeX submission failed:
 
   - [Absolute filenames](#abs_filenames)
   - [Upper-case vs Lower-case filenames](#case_filenames)
-  - [Spaces and other inappropriate characters in filenames](#space_filesnames)
+  - [Spaces and other inappropriate characters in filenames](#space_filenames)
   - [Missing style/macro files](#missing_macro)
   - [Last minute untested changes](#untested)
   - [User intervention](#intervention)
@@ -93,10 +93,12 @@ Look through these common mistakes if your TeX/LaTeX submission failed:
     because filenames are case-sensitive on our system.
     
       
-  - <span id="space_filesnames"></span>**Spaces and other inappropriate characters in filenames**
+  - <span id="space_filenames"></span>**Spaces and other inappropriate 
+    characters in filenames**
+
     Do not use spaces in filenames, in either your figure inclusion commands or directory names. Do not use common filesystem delimiters in file names (*i.e* `/`, `\`, `:`, etc.). Certain symbols such as the ampersand (`&`) can cause problems as well, and should be avoided. 
 
-    During file upload these examples will be programmatically converted to an underscore character (the `_` character). 
+    During file upload these examples will be programmatically converted to an underscore character (the `_` character) in the file names only. You are responsible for updating any inclusion or input commands in your source.  
 
   - <span id="missing_macro"></span>**Missing style/macro files**  
     Some authors write their own style/macro files (or modify standard

--- a/help/submit_tex.md
+++ b/help/submit_tex.md
@@ -176,7 +176,7 @@ Note for submitters who use Overleaf: Please refer to [their help documentation]
 
 ### Avoid mistakes in the text
 
-Common mistakes can be avoided by following some simple [guidelines](faq/mistakes). If your submission does not TeX properly, you will receive the log from our auto-TeXing script at the _Process_ step. The information contained in this complete log should be sufficient to identify the problem, so examine it carefully; check the end of the log for TeX errors.
+Common mistakes can be avoided by following some simple [guidelines](faq/mistakes). If your submission does not TeX properly, you will receive the log from our auto-TeXing script at the _Process_ step. The information contained in this complete log should be sufficient to identify the problem, so examine it carefully; check the end of the log for TeX errors. Be sure to [note any programmatically changed](faq/mistakes#space_filenames) file names during file upload. 
 
 <span id="jhep3"></span>
 

--- a/help/submit_tex.md
+++ b/help/submit_tex.md
@@ -176,7 +176,7 @@ Note for submitters who use Overleaf: Please refer to [their help documentation]
 
 ### Avoid mistakes in the text
 
-Common mistakes can be avoided by following some simple [guidelines](faq/mistakes). If your submission does not TeX properly, you will receive the log from our auto-TeXing script at the _Process_ step. The information contained in this complete log should be sufficient to identify the problem, so examine it carefully; check the end of the log for TeX errors. Be sure to [note any programmatically changed](faq/mistakes#space_filenames) file names during file upload. 
+Common mistakes can be avoided by following some simple [guidelines](faq/mistakes). If your submission does not TeX properly, you will receive the log from our auto-TeXing script at the _Process_ step. The information contained in this complete log should be sufficient to identify the problem, so examine it carefully; check the end of the log for TeX errors. Be sure to [note any programmatically changed](faq/mistakes#space_filenames) filenames during file upload. 
 
 <span id="jhep3"></span>
 


### PR DESCRIPTION
It is a common problem that submitters do not notice when we programmatically update filenames that include spaces or other inappropriate characters. This PR attempts to address that issue in our documentation. 