### PR TITLE
Pause Labs temporarily

### DIFF
--- a/help/stats/2020_by_area/index.html
+++ b/help/stats/2020_by_area/index.html
@@ -50,43 +50,6 @@
   <link rel="stylesheet" href="https://static.arxiv.org/_marxdown/static/arxiv.marxdown/0.1/docs/css/docs.css" />
   <link rel="stylesheet" href="https://static.arxiv.org/_marxdown/static/arxiv.marxdown/0.1/docs/css/codehilite.css" />
 
-  
-
-<script>
-(function(apiKey){
-    (function(p,e,n,d,o){var v,w,x,y,z;o=p[d]=p[d]||{};o._q=[];
-    v=['initialize','identify','updateOptions','pageLoad','track'];for(w=0,x=v.length;w<x;++w)(function(m){
-        o[m]=o[m]||function(){o._q[m===v[0]?'unshift':'push']([m].concat([].slice.call(arguments,0)));};})(v[w]);
-        y=e.createElement(n);y.async=!0;y.src='https://content.analytics.arxiv.org/agent/static/'+apiKey+'/pendo.js';
-        z=e.getElementsByTagName(n)[0];z.parentNode.insertBefore(y,z);})(window,document,'script','pendo');
-
-        // Call this whenever information about your visitors becomes available
-        // Please use Strings, Numbers, or Bools for value types.
-        pendo.initialize({
-            visitor: {
-                id:              'VISITOR-UNIQUE-ID'   // Required if user is logged in
-                // email:        // Recommended if using Pendo Feedback, or NPS Email
-                // full_name:    // Recommended if using Pendo Feedback
-                // role:         // Optional
-                // You can add any additional visitor level key-values here,
-                // as long as it's not one of the above reserved names.
-            },
-
-            account: {
-                id:           'ACCOUNT-UNIQUE-ID' // Highly recommended
-                // name:         // Optional
-                // is_paying:    // Recommended if using Pendo Feedback
-                // monthly_value:// Recommended if using Pendo Feedback
-                // planLevel:    // Optional
-                // planPrice:    // Optional
-                // creationDate: // Optional
-                // You can add any additional account level key-values here,
-                // as long as it's not one of the above reserved names.
-            }
-        });
-})('d6494389-b427-4103-7c76-03182ecc8e60');
-</script>
-
 
   </head>
   <body>

--- a/help/stats/2021_by_area/index.html
+++ b/help/stats/2021_by_area/index.html
@@ -50,44 +50,6 @@
   <link rel="stylesheet" href="https://static.arxiv.org/_marxdown/static/arxiv.marxdown/0.1/docs/css/docs.css" />
   <link rel="stylesheet" href="https://static.arxiv.org/_marxdown/static/arxiv.marxdown/0.1/docs/css/codehilite.css" />
 
-  
-
-<script>
-(function(apiKey){
-    (function(p,e,n,d,o){var v,w,x,y,z;o=p[d]=p[d]||{};o._q=[];
-    v=['initialize','identify','updateOptions','pageLoad','track'];for(w=0,x=v.length;w<x;++w)(function(m){
-        o[m]=o[m]||function(){o._q[m===v[0]?'unshift':'push']([m].concat([].slice.call(arguments,0)));};})(v[w]);
-        y=e.createElement(n);y.async=!0;y.src='https://content.analytics.arxiv.org/agent/static/'+apiKey+'/pendo.js';
-        z=e.getElementsByTagName(n)[0];z.parentNode.insertBefore(y,z);})(window,document,'script','pendo');
-
-        // Call this whenever information about your visitors becomes available
-        // Please use Strings, Numbers, or Bools for value types.
-        pendo.initialize({
-            visitor: {
-                id:              'VISITOR-UNIQUE-ID'   // Required if user is logged in
-                // email:        // Recommended if using Pendo Feedback, or NPS Email
-                // full_name:    // Recommended if using Pendo Feedback
-                // role:         // Optional
-                // You can add any additional visitor level key-values here,
-                // as long as it's not one of the above reserved names.
-            },
-
-            account: {
-                id:           'ACCOUNT-UNIQUE-ID' // Highly recommended
-                // name:         // Optional
-                // is_paying:    // Recommended if using Pendo Feedback
-                // monthly_value:// Recommended if using Pendo Feedback
-                // planLevel:    // Optional
-                // planPrice:    // Optional
-                // creationDate: // Optional
-                // You can add any additional account level key-values here,
-                // as long as it's not one of the above reserved names.
-            }
-        });
-})('d6494389-b427-4103-7c76-03182ecc8e60');
-</script>
-
-
   </head>
   <body>
   

--- a/labs/criteria.md
+++ b/labs/criteria.md
@@ -1,41 +1,6 @@
-{% macro pendo() %}
-<script>
-(function(apiKey){
-    (function(p,e,n,d,o){var v,w,x,y,z;o=p[d]=p[d]||{};o._q=[];
-    v=['initialize','identify','updateOptions','pageLoad','track'];for(w=0,x=v.length;w<x;++w)(function(m){
-        o[m]=o[m]||function(){o._q[m===v[0]?'unshift':'push']([m].concat([].slice.call(arguments,0)));};})(v[w]);
-        y=e.createElement(n);y.async=!0;y.src='https://content.analytics.arxiv.org/agent/static/'+apiKey+'/pendo.js';
-        z=e.getElementsByTagName(n)[0];z.parentNode.insertBefore(y,z);})(window,document,'script','pendo');
-
-        // Call this whenever information about your visitors becomes available
-        // Please use Strings, Numbers, or Bools for value types.
-        pendo.initialize({
-            visitor: {
-                id:              'arxiv-labs-user'   // Required if user is logged in
-                // email:        // Recommended if using Pendo Feedback, or NPS Email
-                // full_name:    // Recommended if using Pendo Feedback
-                // role:         // Optional
-                // You can add any additional visitor level key-values here,
-                // as long as it's not one of the above reserved names.
-            },
-
-            account: {
-                id:           'ARXIV-LABS' // Highly recommended
-                // name:         // Optional
-                // is_paying:    // Recommended if using Pendo Feedback
-                // monthly_value:// Recommended if using Pendo Feedback
-                // planLevel:    // Optional
-                // planPrice:    // Optional
-                // creationDate: // Optional
-                // You can add any additional account level key-values here,
-                // as long as it's not one of the above reserved names.
-            }
-        });
-})('d6494389-b427-4103-7c76-03182ecc8e60');
-</script>
-{% endmacro %}
-{{ pendo() }}
 # arXivLabs Criteria
+
+_*arXiv Labs is temporarily on pause while arXiv is focused on stability and moving to the cloud. Please check back in six months.*_
 
 <style>
 blockquote {

--- a/labs/index.md
+++ b/labs/index.md
@@ -111,44 +111,6 @@ aside {
 }
 </style>
 
-{% macro pendo() %}
-<script>
-(function(apiKey){
-    (function(p,e,n,d,o){var v,w,x,y,z;o=p[d]=p[d]||{};o._q=[];
-    v=['initialize','identify','updateOptions','pageLoad','track'];for(w=0,x=v.length;w<x;++w)(function(m){
-        o[m]=o[m]||function(){o._q[m===v[0]?'unshift':'push']([m].concat([].slice.call(arguments,0)));};})(v[w]);
-        y=e.createElement(n);y.async=!0;y.src='https://content.analytics.arxiv.org/agent/static/'+apiKey+'/pendo.js';
-        z=e.getElementsByTagName(n)[0];z.parentNode.insertBefore(y,z);})(window,document,'script','pendo');
-
-        // Call this whenever information about your visitors becomes available
-        // Please use Strings, Numbers, or Bools for value types.
-        pendo.initialize({
-            visitor: {
-                id:              'arxiv-labs-user'   // Required if user is logged in
-                // email:        // Recommended if using Pendo Feedback, or NPS Email
-                // full_name:    // Recommended if using Pendo Feedback
-                // role:         // Optional
-                // You can add any additional visitor level key-values here,
-                // as long as it's not one of the above reserved names.
-            },
-
-            account: {
-                id:           'ARXIV-LABS' // Highly recommended
-                // name:         // Optional
-                // is_paying:    // Recommended if using Pendo Feedback
-                // monthly_value:// Recommended if using Pendo Feedback
-                // planLevel:    // Optional
-                // planPrice:    // Optional
-                // creationDate: // Optional
-                // You can add any additional account level key-values here,
-                // as long as it's not one of the above reserved names.
-            }
-        });
-})('d6494389-b427-4103-7c76-03182ecc8e60');
-</script>
-{% endmacro %}
-{{ pendo() }}
-
 <img alt="arXivLabs logo" src="images/smileybones-labs-icon.png" class="mkd-img-right mkd-img-thumb"/>
 
 arXivLabs is a framework for enabling the arXiv community to contribute to arXiv and develop tools that can benefit the scientific community. Current projects are featured in our [arXivLabs showcase](showcase/).
@@ -164,10 +126,12 @@ arXiv welcomes anyone, from single individuals to large companies, to contribute
 > 1. **Core**
 > Experimental projects that add a great deal of value to the arXiv platform, and which are deemed feasible to maintain by the core arXiv IT team, may be incorporated as a core feature or service. These projects undergo additional rigorous scrutiny to ensure maintainability, security, and reliability.
 
-To apply to the arXivLabs community, learn more about the [criteria](criteria) and then [propose your project idea](project-proposal).
+<!-- To apply to the arXivLabs community, learn more about the [criteria](criteria) and then [propose your project idea](project-proposal). -->
 
-<a href="project-proposal" class="button-fancy">Click to submit your idea <span> </span></a>
+<!-- <a href="project-proposal" class="button-fancy">Click to submit your idea <span> </span></a> -->
 
-Please also note that many projects that use APIs and other methods to access arXiv's metadata, full text, or source files are **not** arXivLabs projects. Learn more about [arXiv API access and data usage here.](https://arxiv.org/help/api/)
+_*arXiv Labs is temporarily on pause while arXiv is focused on stability and moving to the cloud. Please check back in six months.*_ In the meantime, you can learn more about the [criteria](criteria) for arXiv Labs projects.
+
+This pause in Labs effort does not affect access to the arXiv APIs, which are always public and available. Please also note that many projects that use APIs and other methods to access arXiv's metadata, full text, or source files are **not** arXivLabs projects. Learn more about [arXiv API access and data usage here.](https://arxiv.org/help/api/)
 
 _Note: Use of the names “arXiv”, “arXiv.org”, “arXiv Labs”, “arXivLabs” and associated logos, web addresses, and colors are only allowed with the explicit written permission from the arXiv management team._

--- a/labs/project-proposal.md
+++ b/labs/project-proposal.md
@@ -1,40 +1,3 @@
-{% macro pendo() %}
-<script>
-(function(apiKey){
-    (function(p,e,n,d,o){var v,w,x,y,z;o=p[d]=p[d]||{};o._q=[];
-    v=['initialize','identify','updateOptions','pageLoad','track'];for(w=0,x=v.length;w<x;++w)(function(m){
-        o[m]=o[m]||function(){o._q[m===v[0]?'unshift':'push']([m].concat([].slice.call(arguments,0)));};})(v[w]);
-        y=e.createElement(n);y.async=!0;y.src='https://content.analytics.arxiv.org/agent/static/'+apiKey+'/pendo.js';
-        z=e.getElementsByTagName(n)[0];z.parentNode.insertBefore(y,z);})(window,document,'script','pendo');
-
-        // Call this whenever information about your visitors becomes available
-        // Please use Strings, Numbers, or Bools for value types.
-        pendo.initialize({
-            visitor: {
-                id:              'arxiv-labs-user'   // Required if user is logged in
-                // email:        // Recommended if using Pendo Feedback, or NPS Email
-                // full_name:    // Recommended if using Pendo Feedback
-                // role:         // Optional
-                // You can add any additional visitor level key-values here,
-                // as long as it's not one of the above reserved names.
-            },
-
-            account: {
-                id:           'ARXIV-LABS' // Highly recommended
-                // name:         // Optional
-                // is_paying:    // Recommended if using Pendo Feedback
-                // monthly_value:// Recommended if using Pendo Feedback
-                // planLevel:    // Optional
-                // planPrice:    // Optional
-                // creationDate: // Optional
-                // You can add any additional account level key-values here,
-                // as long as it's not one of the above reserved names.
-            }
-        });
-})('d6494389-b427-4103-7c76-03182ecc8e60');
-</script>
-{% endmacro %}
-{{ pendo() }}
 # Submit your project to arXivLabs
 
 <style>
@@ -66,10 +29,17 @@ blockquote {
   }
 }
 </style>
-arXiv welcomes anyone, from single individuals to large companies, to contribute ideas and propose their project for arXivLabs. All projects must abide by arXiv’s values of openness, community, excellence, and user data privacy. Learn more about arXiv's [Labs criteria](criteria) and [API data usage](https://arxiv.org/help/api/).
 
-To propose a project fill out all fields in our project proposal form. _Scroll within the frame_ below to access the full form and fill out all fields on each page (a total of four steps).
+_*arXiv Labs is temporarily on pause while arXiv is focused on stability and moving to the cloud. Please check back in six months.*_
 
-<iframe src="https://cornell.ca1.qualtrics.com/jfe/form/SV_6utTdLVDVlaTz5Y" height="750px" width="100%" class="form-proposals" title="submit a proposal to arxiv labs"></iframe>
+In the meantime, learn more about arXiv's [Labs criteria](criteria) for Labs projects.
 
-_Is the form above not displaying? <a href="https://cornell.ca1.qualtrics.com/jfe/form/SV_6utTdLVDVlaTz5Y">Open it in Qualtrics</a>_
+This pause in Labs effort does not affect access to the arXiv APIs, which are always public and available. Please also note that many projects that use APIs and other methods to access arXiv's metadata, full text, or source files are **not** arXivLabs projects. Learn more about [arXiv API access and data usage here.](https://arxiv.org/help/api/)
+
+<!-- arXiv welcomes anyone, from single individuals to large companies, to contribute ideas and propose their project for arXivLabs. All projects must abide by arXiv’s values of openness, community, excellence, and user data privacy.  -->
+
+<!-- To propose a project fill out all fields in our project proposal form. _Scroll within the frame_ below to access the full form and fill out all fields on each page (a total of four steps). -->
+
+<!-- <iframe src="https://cornell.ca1.qualtrics.com/jfe/form/SV_6utTdLVDVlaTz5Y" height="750px" width="100%" class="form-proposals" title="submit a proposal to arxiv labs"></iframe> -->
+
+<!-- _Is the form above not displaying? <a href="https://cornell.ca1.qualtrics.com/jfe/form/SV_6utTdLVDVlaTz5Y">Open it in Qualtrics</a>_ -->

--- a/labs/showcase.md
+++ b/labs/showcase.md
@@ -161,59 +161,23 @@ h1#arxivlabs {
 </article>
 {% endmacro %}
 
-
-{% macro pendo() %}
-<script>
-(function(apiKey){
-    (function(p,e,n,d,o){var v,w,x,y,z;o=p[d]=p[d]||{};o._q=[];
-    v=['initialize','identify','updateOptions','pageLoad','track'];for(w=0,x=v.length;w<x;++w)(function(m){
-        o[m]=o[m]||function(){o._q[m===v[0]?'unshift':'push']([m].concat([].slice.call(arguments,0)));};})(v[w]);
-        y=e.createElement(n);y.async=!0;y.src='https://content.analytics.arxiv.org/agent/static/'+apiKey+'/pendo.js';
-        z=e.getElementsByTagName(n)[0];z.parentNode.insertBefore(y,z);})(window,document,'script','pendo');
-
-        // Call this whenever information about your visitors becomes available
-        // Please use Strings, Numbers, or Bools for value types.
-        pendo.initialize({
-            visitor: {
-                id:              'arxiv-labs-user'   // Required if user is logged in
-                // email:        // Recommended if using Pendo Feedback, or NPS Email
-                // full_name:    // Recommended if using Pendo Feedback
-                // role:         // Optional
-                // You can add any additional visitor level key-values here,
-                // as long as it's not one of the above reserved names.
-            },
-
-            account: {
-                id:           'ARXIV-LABS' // Highly recommended
-                // name:         // Optional
-                // is_paying:    // Recommended if using Pendo Feedback
-                // monthly_value:// Recommended if using Pendo Feedback
-                // planLevel:    // Optional
-                // planPrice:    // Optional
-                // creationDate: // Optional
-                // You can add any additional account level key-values here,
-                // as long as it's not one of the above reserved names.
-            }
-        });
-})('d6494389-b427-4103-7c76-03182ecc8e60');
-</script>
-{% endmacro %}
-{{ pendo() }}
 # arXivLabs: Showcase
 
 arXiv is surrounded by a community of researchers and developers working at the cutting edge of information science and technology.
 
 While the arXiv team is focused on our core mission—providing rapid dissemination of research findings at no cost to readers and submitters—we are excited to be experimenting with a small number of collaborators on projects that add value for our stakeholders and advance research.
 
-Below are some of the projects that our collaborators are working on right now.
+Interested in proposing a new arXiv Labs project? _*Note that arXiv Labs is temporarily on pause while arXiv is focused on stability and moving to the cloud. Please check back in six months.*_
 
-Interested in proposing a new arXiv Labs project?
+Below are some of the projects that our collaborators have done.
 
-<a href="/project-proposal" class="button-fancy">Click to submit your idea <span> </span></a>
+<!-- <a href="/project-proposal" class="button-fancy">Click to submit your idea <span> </span></a> -->
+
 {{ render_project(page.meta.projects.litmaps) }}
 {{ render_project(page.meta.projects.connected_papers) }}
 {{ render_project(page.meta.projects.pwc_links) }}
 {{ render_project(page.meta.projects.core_recommender) }}
 {{ render_project(page.meta.projects.bibliographic_overlay) }}
+
 <br/>
 We are grateful to the [volunteer developers](https://arxiv.org/about/people/developers) who contribute to the arXiv codebase and invite you to get involved. Please see the [arXivLabs invitation to collaborate](/) and [guidelines for contributors](https://github.com/arXiv/.github/blob/master/CONTRIBUTING.md), or contact nextgen@arxiv.org, for more information about contributing to arXivLabs.


### PR DESCRIPTION
This minimal PR updates labs messaging to note that effort is on pause. We hide links to the proposal form, and in case anyone stumbles on that page also hide the form itself. On an unrelated note, also removed pendo related code.

Here are screenshots of the text changes:

The main page:
![Labs-index](https://user-images.githubusercontent.com/56078140/169537014-c5788a71-1fc8-499f-b702-e790d60a6990.png)

The showcase page:
![labs-showcase](https://user-images.githubusercontent.com/56078140/169537009-05ff3182-fd30-4e5c-af76-88b53c87f681.png)

Labs criteria page:
![labs-criteria](https://user-images.githubusercontent.com/56078140/169537011-20c1f400-9dfb-4b24-82af-c1a1b2fe8447.png)

And in case anyone stumbles on the proposal page, it looks like this:
![labs-proposal](https://user-images.githubusercontent.com/56078140/169537006-46336092-d256-4ef3-ac0b-0cf14db3ab70.png)

