### PR TITLE
Fixed broken link for feedparser

### DIFF
--- a/help/api/basics.md
+++ b/help/api/basics.md
@@ -109,7 +109,7 @@ include:
     ([example](#perl_simple_example))
 
   - [Python](http://www.python.org) (via
-    [feedparser](http://feedparser.org/))
+    [feedparser](https://github.com/kurtmckee/feedparser))
     ([example](#python_simple_example))
 
   - [Ruby](http://www.ruby-lang.org) (via


### PR DESCRIPTION
[Feedparser](https://pypi.org/project/feedparser/) seems to be abandoning their old homepage [since 2019](https://github.com/kurtmckee/feedparser/issues/166). This fix updates the URL to [the GitHub link of feedparser](https://github.com/kurtmckee/feedparser), but it also can be [the PyPI link](https://pypi.org/project/feedparser).

This is just a quick fix 🥂