### PR TITLE
Adds additional information related to allowing long urls to break across lines

### DIFF
--- a/help/faq/texprobs.md
+++ b/help/faq/texprobs.md
@@ -66,8 +66,8 @@ arXiv's default behavior for [hyperref](/help/hypertex) is to have hyperlinks (a
 
 For more information please consult the [hyperref manual](https://ctan.org/pkg/hyperref). 
 
-Note that this primarily impacts links that are created with the `\href` construct. If you are tying to make use of long
-URL with the `\url` construct, we recommend that you make use of the `url` package with the `[hyphens]` option ([see its documentation](https://ctan.org/pkg/url)). This package typically has to be loaded before hyperref. Another option if this 
+Note that this primarily impacts links that are created with the `\href` construct. If you are trying to make use of long
+URL with the `\url` construct, we recommend that you make use of the `url` package with the `[hyphens]` option ([see its documentation](https://ctan.org/pkg/url)). This package typically has to be loaded before hyperref. If this 
 doesn't provide the functionality you seek (e.g. in dvi mode), you may wish to use the `breakurl` package, which performs some 
 of these same features. Consult [the package documentation](https://ctan.org/pkg/breakurl) for usage instructions.
 

--- a/help/faq/texprobs.md
+++ b/help/faq/texprobs.md
@@ -69,7 +69,7 @@ For more information please consult the [hyperref manual](https://ctan.org/pkg/h
 Note that this primarily impacts links that are created with the `\href` construct. If you are tying to make use of long
 URL with the `\url` construct, we recommend that you make use of the `url` package with the `[hyphens]` option ([see its documentation](https://ctan.org/pkg/url)). This package typically has to be loaded before hyperref. Another option if this 
 doesn't provide the functionality you seek (e.g. in dvi mode), you may wish to use the `breakurl` package, which performs some 
-of these same features. Consult [the package documentation](https://ctan.org/pkg/breakurl) for useage instructions.
+of these same features. Consult [the package documentation](https://ctan.org/pkg/breakurl) for usage instructions.
 
 
 

--- a/help/faq/texprobs.md
+++ b/help/faq/texprobs.md
@@ -65,6 +65,14 @@ arXiv's default behavior for [hyperref](/help/hypertex) is to have hyperlinks (a
 ```
 
 For more information please consult the [hyperref manual](https://ctan.org/pkg/hyperref). 
+
+Note that this primarily impacts links that are created with the `\href` construct. If you are tying to make use of long
+URL with the `\url` construct, we recommend that you make use of the `url` package with the `[hyphens]` option ([see its documentation](https://ctan.org/pkg/url)). This package typically has to be loaded before hyperref. Another option if this 
+doesn't provide the functionality you seek (e.g. in dvi mode), you may wish to use the `breakurl` package, which performs some 
+of these same features. Consult [the package documentation](https://ctan.org/pkg/breakurl) for useage instructions.
+
+
+
     
   - <span id="fuzzy_pdf"></span>**Fuzzy fonts in PDF**  
     If you use the `fontenc` package and `T1` fonts you may find that


### PR DESCRIPTION
It was brought to our attention that the line breaking for urls doesn't work as documented in both dvi and pdf modes. This PR attempts to bridge that gap to provide some work arounds and links to relevant packages. 