### PR TITLE
Clarifies details regarding ASCII requirements in the subscription help page

### DIFF
--- a/help/subscribe.md
+++ b/help/subscribe.md
@@ -3,8 +3,8 @@ To Subscribe to the E-Mail Alerting Service
 
 If you would like to receive regular daily listings of the abstracts of
 new submissions by email, then you can subscribe to this service as
-follows. Note that the email must be sent as **plain text**. Richtext format 
-emails will be ignored by the system.
+follows. Note that the email must be sent as **plain ASCII txt**. Richtext format
+emails will be ignored by the system, as will UTF-8 characters within the `Subject` field.
 
 1.  Determine which archive is of interest to you, and obtain its e-mail
     address from the [list of available archives](/category_taxonomy).

--- a/source/help/subscribe.md
+++ b/source/help/subscribe.md
@@ -2,8 +2,8 @@
 
 If you would like to receive regular daily listings of the abstracts of
 new submissions by email, then you can subscribe to this service as
-follows. Note that the email must be sent as **plain text**. Richtext format
-emails will be ignored by the system.
+follows. Note that the email must be sent as **plain ASCII txt**. Richtext format
+emails will be ignored by the system, as will UTF-8 characters within the `Subject` field. 
 
 1.  Determine which archive is of interest to you, and obtain its e-mail
     address from the [list of available archives](https://arxiv.org/category_taxonomy)


### PR DESCRIPTION
Users who have UTF8 characters in their name within the Subject field will fail silently. This address that in our documentation. 