### PR TITLE
more fixes to broken links

### DIFF
--- a/help/robots.md
+++ b/help/robots.md
@@ -27,7 +27,7 @@ ignorant of common sense
 
 Following the de-facto [standard for robot
 exclusion](http://www.robotstxt.org/orig.html), this site has maintained
-since early 1994 a file /[robots.txt](/robots.txt) that specifies those
+since early 1994 a file /[robots.txt](https://arxiv.org/robots.txt) that specifies those
 URL's that are off-limits to robots (and this "Robots Beware" page was
 originally posted March 1994).
 
@@ -35,7 +35,7 @@ Mindlessly downloading all of the URLs on this site will return
 terabytes of data. This has very real cost to us in terms of bandwidth
 consumed, and in terms of the responsiveness of our service.
 
-arXiv monitors activity and will deny access to sites that violate these 
+arXiv monitors activity and will deny access to sites that violate these
 guidelines. Continued rapid-fire requests from
 any site after access has been denied (i.e. with `403: Access denied`
 HTTP response) will be interpreted as an attack; and we will respond

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -8,6 +8,7 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title> | arXiv e-print repository</title>
+<link rel="stylesheet" href="https://use.typekit.net/kkn2tyz.css">
 <script type="text/x-mathjax-config">
   MathJax.Hub.Config({
     messageStyle: "none",

--- a/source/SUMMARY.md
+++ b/source/SUMMARY.md
@@ -55,6 +55,7 @@
           * [Institutional Repository Interoperability](help/ir.md)
           * [Automated DOI and journal reference updates from publishers](help/bib_feed.md)
 * [Brand](brand/index.md)
+    - [Logo Use](brand/brand-guidelines.md)
     - brand/*.md
 * [Labs](labs/index.md)
     - labs/*.md

--- a/source/about/funding.md
+++ b/source/about/funding.md
@@ -13,7 +13,7 @@ arXiv’s financial sustainability depends on maintaining funding sources that a
   <li><strong>Affiliates</strong><br>
   <a href="supporters.html">Professional societies, government agencies, and other nonprofits</a> are welcome to collaborate with arXiv in a variety of ways, from facilitating conference proceeding submissions to promoting open access compliance and more. Suggested contribution levels range from $5,000 to $100,000. <a href="support_confirm.html">Become an affiliate.</a></li>
   <li><strong>Sponsors</strong><br>
-  <a href="suporters.html">Companies</a> that benefit from arXiv's services are encouraged to support the infrastructure with both funding and in-kind donations such as developer time and cloud services. Suggested contribution levels range from $10,000 to $200,000, or the in-kind equivalent. <a href="support_confirm.html">Become a sponsor</a>.</li>
+  <a href="supporters.html">Companies</a> that benefit from arXiv's services are encouraged to support the infrastructure with both funding and in-kind donations such as developer time and cloud services. Suggested contribution levels range from $10,000 to $200,000, or the in-kind equivalent. <a href="support_confirm.html">Become a sponsor</a>.</li>
 </ol>
 
 [Donate Today](https://securelb.imodules.com/s/1717/alumni/event.aspx?sid=1717&gid=2&pgid=22315&cid=35778&dids=276&bledit=1&sort=1){.button-reg}

--- a/source/about/index.md
+++ b/source/about/index.md
@@ -35,7 +35,7 @@ Registered users may [submit articles](../help/submit.md) to be announced by arX
 - Section Advisory Committees
 	- [Physics](../help/physics/index.md#AdvisoryCommittee)
 	- [Mathematics](../help/math/index.md#AdvisoryCommittee)
-	- [Computer science (CoRR)](../corr/index.md)
+	- [Computer science (CoRR)](../help/cs/index.md)
 	- [Quantitative biology](../help/q-bio/index.md#AdvisoryCommittee)
 	- [Quantitative finance](../help/q-fin/index.md#AdvisoryCommittee)
 	- [Statistics](../help/statistics/index.md#AdvisoryCommittee)

--- a/source/about/reports/2009_usage.md
+++ b/source/about/reports/2009_usage.md
@@ -3,7 +3,7 @@
 
 The following table is a compilation of arXiv downloads for calendar
 year 2009 for the 200 heaviest user institutions. See also [arXiv
-Support](../../help/support.md).
+Support](../../about/governance.md).
 
 **Caveats:** While we have taken considerable effort to extract reliable
 download data representing unique full-text downloads by real users,

--- a/source/about/reports/2010_usage.md
+++ b/source/about/reports/2010_usage.md
@@ -3,7 +3,7 @@
 
 The following table is a compilation of arXiv downloads for calendar
 year 2010 for the 200 heaviest user institutions. See also [arXiv
-Support](../../help/support.md).
+Support](../../about/governance.md).
 
 **Caveats:** While we have taken considerable effort to extract reliable
 download data representing unique full-text downloads by real users,

--- a/source/about/reports/2011_usage.md
+++ b/source/about/reports/2011_usage.md
@@ -3,7 +3,7 @@
 
 The following table is a compilation of arXiv downloads for calendar
 year 2011 for the 200 heaviest user institutions. See also [arXiv
-Support](../../help/support.md).
+Support](../../about/governance.md).
 
 **Caveats:** While we have taken considerable effort to extract reliable
 download data representing unique full-text downloads by real users,

--- a/source/about/reports/2012_usage.md
+++ b/source/about/reports/2012_usage.md
@@ -3,7 +3,7 @@
 
 The following table is a compilation of arXiv downloads for calendar
 year 2012 for the 200 heaviest user institutions. See also [arXiv
-Support](../../help/support.md).
+Support](../../about/governance.md).
 
 **Caveats:** While we have taken considerable effort to extract reliable
 download data representing unique full-text downloads by real users,

--- a/source/about/reports/2013_usage.md
+++ b/source/about/reports/2013_usage.md
@@ -3,7 +3,7 @@
 
 The following table is a compilation of arXiv downloads for calendar
 year 2013 for the 200 heaviest user institutions. See also [arXiv
-Support](../../help/support.md).
+Support](../../about/governance.md).
 
 **Caveats:** While we have taken considerable effort to extract reliable
 download data representing unique full-text downloads by real users,

--- a/source/about/reports/2014_usage.md
+++ b/source/about/reports/2014_usage.md
@@ -3,7 +3,7 @@
 
 The following table is a compilation of arXiv downloads for calendar
 year 2014 for the 200 heaviest user institutions. See also [arXiv
-Support](../../help/support.md).
+Support](../../about/governance.md).
 
 **Caveats:** While we have taken considerable effort to extract reliable
 download data representing unique full-text downloads by real users,

--- a/source/about/reports/2015_usage.md
+++ b/source/about/reports/2015_usage.md
@@ -3,7 +3,7 @@
 
 The following table is a compilation of arXiv downloads for calendar
 year 2015 for the 200 heaviest user institutions. See also [arXiv
-Support](../../help/support.md).
+Support](../../about/governance.md).
 
 **Caveats:** While we have taken considerable effort to extract reliable
 download data representing unique full-text downloads by real users,

--- a/source/about/reports/2016_usage.md
+++ b/source/about/reports/2016_usage.md
@@ -3,7 +3,7 @@
 
 The following table is a compilation of arXiv downloads for calendar
 year 2016 for the 200 heaviest user institutions. See also [arXiv
-Support](../../help/support.md).
+Support](../../about/governance.md).
 
 **Caveats:** While we have taken considerable effort to extract reliable
 download data representing unique full-text downloads by real users,

--- a/source/about/reports/2017_usage.md
+++ b/source/about/reports/2017_usage.md
@@ -3,7 +3,7 @@
 
 The following table is a compilation of arXiv downloads for calendar
 year 2017 for the 200 heaviest user institutions. See also [arXiv
-Support](../../help/support.md).
+Support](../../about/governance.md).
 
 **Caveats:** While we have taken considerable effort to extract reliable
 download data representing unique full-text downloads by real users,

--- a/source/about/reports/2018_usage.md
+++ b/source/about/reports/2018_usage.md
@@ -3,7 +3,7 @@
 
 The following table is a compilation of arXiv downloads for calendar
 year 2018 for the 250 heaviest user institutions. See also [arXiv
-Support](../../help/support.md).
+Support](../../about/governance.md).
 
 **Caveats:** While we have taken considerable effort to extract reliable
 download data representing unique full-text downloads by real users,

--- a/source/about/reports/arxiv_busplan_Dec2010.md
+++ b/source/about/reports/arxiv_busplan_Dec2010.md
@@ -44,7 +44,7 @@ advisory group, which serves an essential consultative role in assisting
 Cornell develop diverse sustainability strategies.
 
 More information about our sustainability and business planning efforts
-is available at [http://arxiv.org/help/support](../../help/support.md).
+is available at [http://arxiv.org/help/support](../../about/governance.md).
 
 We thank all our [supporters](2010_supporters.md) and welcome
 questions and suggestions.

--- a/source/about/reports/arxiv_busplan_Jan2012.md
+++ b/source/about/reports/arxiv_busplan_Jan2012.md
@@ -97,7 +97,7 @@ of the February planning meetings, we expect to announce a model for
 **Communication**
 
 The arXiv sustainability initiative's website is
-[http://arxiv.org/help/support](../../help/support.md), including the quarterly
+[http://arxiv.org/help/support](../../about/governance.md), including the quarterly
 updates. You are also welcome to send your questions and input to
 support@arxiv.org. We have an email list for sharing updates about
 arXiv support efforts. If you received this update directly, you are

--- a/source/about/reports/arxiv_busplan_July2010.md
+++ b/source/about/reports/arxiv_busplan_July2010.md
@@ -43,7 +43,7 @@ understand how we can include them in our collaborative business
 modeling process.
 
 More information about our sustainability and business planning efforts
-is available at [http://arxiv.org/help/support](../../help/support.md).
+is available at [http://arxiv.org/help/support](../../about/governance.md).
 
 We thank all our supporters and welcome questions and suggestions.
 

--- a/source/about/reports/arxiv_busplan_July2011.md
+++ b/source/about/reports/arxiv_busplan_July2011.md
@@ -132,7 +132,7 @@ potentially cover the expenses associated with running arXiv?**
 planning initiative?**
 
 > The arXiv sustainability initiative's website is
-> [http://arxiv.org/help/support](../../help/support.md), and we will continue
+> [http://arxiv.org/help/support](../../about/governance.md), and we will continue
 > to post quarterly updates there. You are also welcome to send your
 > questions and input to <support@arxiv.org>. We have recently created
 > an announcement email list for updates about arXiv support efforts,

--- a/source/about/reports/arxiv_busplan_Oct2011.md
+++ b/source/about/reports/arxiv_busplan_Oct2011.md
@@ -90,7 +90,7 @@ provide. We welcome your suggestions for additional metrics.
 **Communication**
 
 The arXiv sustainability initiative's website is
-[http://arxiv.org/help/support](../../help/support.md), including the quarterly
+[http://arxiv.org/help/support](../../about/governance.md), including the quarterly
 updates. You are also welcome to send your questions and input to
 <support@arxiv.org>. We have recently created an announcement email list
 for updates about arXiv support efforts, and we have transferred all of

--- a/source/about/reports/sustainability_advisory_group.md
+++ b/source/about/reports/sustainability_advisory_group.md
@@ -3,7 +3,7 @@ arXiv Sustainability Advisory Group
 
 Cornell University Library  
 August 5, 2010; last updated September 7, 2010  
-See also: [arXiv Support](../../help/support.md)  
+See also: [arXiv Support](../../about/governance.md)  
 Contact: <support@arxiv.org>
 
 Purpose of the Sustainability Advisory Group

--- a/source/about/reports/whitepaper.md
+++ b/source/about/reports/whitepaper.md
@@ -2,7 +2,7 @@
 
 Cornell University Library  
 January 15, 2010; last updated August 5, 2010  
-See also: [arXiv Support](../../help/support.md) and [FAQ](../../help/faq/index.md)
+See also: [arXiv Support](../../about/governance.md) and [FAQ](../../help/faq/index.md)
 Contact: support@arxiv.org
 
 ## 1. Introduction

--- a/source/about/supporters.md
+++ b/source/about/supporters.md
@@ -1,9 +1,9 @@
 # Our Supporters
 
-We gratefully acknowledge the support of the following organizations, which contribute funding and in-kind contributions that complement support from [members](members).
+We gratefully acknowledge the support of the following organizations, which contribute funding and in-kind contributions that complement support from [members](ourmembers.md).
 {.intro}
 
-Interested in supporting arXiv and expanding the possibilities of open science? Learn more about [arXiv's funding](funding) and contact us at membership@arXiv.org.
+Interested in supporting arXiv and expanding the possibilities of open science? Learn more about [arXiv's funding](funding.md) and contact us at membership@arXiv.org.
 
 <div class="mkd-ordered-list-blocks" markdown="1">
 

--- a/source/brand/brand-guidelines.md
+++ b/source/brand/brand-guidelines.md
@@ -1,13 +1,11 @@
-#Brand Use Guidelines
-
-Using our logo consistently is important to present a unified message to the world about who we are. That message is:
-{.intro}
-
-**arXiv is a place of connection, linking together people and ideas, and connecting them with the world of open science.**
+#Logo and Brand Use
 
 Unauthorized use of our logo causes confusion about who we are. And when it’s use is authorized it’s just as important that we follow consistent guidelines to preserve the legibility, memorability, and legal defensibility that arXiv needs to protect this vital scientific service.
+{.intro}
 
-The arXiv logo is Federally trademarked and the legal property of arXiv and Cornell University, protected against unauthorized use. Our logo is ready to help us share a consistent, intentional, and meaningful message about who we are with the world.
+Using our logo consistently is important to present a unified message to the world about who we are. That message is: *arXiv is a place of connection, linking together people and ideas, and connecting them with the world of open science.*
+
+The arXiv logo is a registered trademark and the legal property of arXiv and Cornell University, protected against unauthorized use. Our logo is ready to help us share a consistent, intentional, and meaningful message about who we are with the world.
 
 ##General guidelines that cover all logo use cases
 1. Use of the name arXiv and associated logos, web addresses, and colors are only allowed with explicit written permission from the arXiv management team.

--- a/source/brand/colors.md
+++ b/source/brand/colors.md
@@ -136,9 +136,9 @@ Sufficient color contrast is one of the pillars of accessibility on the web. The
 
 **Button combinations**
 
-[Regular Button](testlinkonly){.button-reg}
+[Regular Button](#){.button-reg}
 
-[Large Button](testlinkonly){.button-large}
+[Large Button](#){.button-large}
 
 ##Special Combinations for Large Font Sizes
 In addition to all of the color combinations above, some additional color combinations are available for headings and font sizes 19px or larger.

--- a/source/brand/images.md
+++ b/source/brand/images.md
@@ -2,23 +2,19 @@
 arXiv's branding uses both photographs and illustrations. Photos are used alone or paired with our [tagline](tagline.html). Illustrations capture abstract concepts well and are used in presentations and documentation.
 {.intro}
 
-**Important: Images may only be used for arXiv-owned materials.** All assets within arXiv image libraries have been cleared for use in arXiv materials. Use in materials outside of arXiv is not covered by copyright.
+**Important: Images may only be used for arXiv-owned materials.** All assets within arXiv image libraries have been cleared only for use in arXiv-owned platforms, messaging and communication.
 
 ##Photos
-[Go to the arXiv Photo Library](https://cornell.box.com/v/arXiv-photo-library)
-
 Photographs are an important part of the arXiv visual brand. Our curated photo collection represent academic spaces, researchers, labs, and other research-related subject matter. Images of the Cornell and Cornell Tech campuses help create a sense of place, and portraiture humanizes the vast community of people who rely on arXiv.
 
-We apply color washes to photos in our [brand colors](colors.html).
+We apply color washes to photos in our [brand colors](colors.html):
 ![photo of Cornell campus with salmon overlay](images/brand-image-colorized-salmon.jpg){.mkd-img-full alt='Cornell's campus in the springtime. A student walks near the famous clocktower below flowering trees.'}
 
-Photographs can be overlayed with a [tagline](tagline.html) as shown here.
+Photographs can be overlayed with a [tagline](tagline.html):
 ![photo of CU Tech campus with tagline](images/brand-image-tagline.jpg){.mkd-full alt='An image of arXiv's home at Cornell Tech overlayed with the tagline arXiv Connects old and new ways of publishing.'}  
 
 ##Illustrations
-[Go to the arXiv Illustration library](https://cornell.box.com/v/arXiv-illustration-library)
-
-Illustrations are used to represent abstract concepts or stakeholder groups. The illustrative style we use is informal and friendly. It is not slick or polished, but emphasizes thrift and mission focus, with a touch of gentle humor.
+Illustrations are used to represent abstract concepts or stakeholder groups. The illustrative style we use is informal and friendly. It is not slick or polished, but emphasizes mission focus with a touch of gentle humor.
 
 <div class="grid-blocks">
   <img src="images/brand-image-illustration-1.jpg" role="presentation" class="shadow">
@@ -38,14 +34,5 @@ This resource holds a wide variety of cleared images of people and campus locati
 [CORNELL TECH IMAGE LIBRARY TOP 100](https://cornell.app.box.com/s/rpl81q6go7s9qq0nm7ndw2tw7hfh8079)
 A curated collection from Cornell Tech, including images of campus, conferences and social gatherings, research discoveries, and more.
 
-[LIBRARY OF CONGRESS ONLINE CATALOG](http://www.loc.gov/pictures/search/CU)
-This vast image collection includes free and unlicensed historical images related to scientific discovery.
-
-[FACULTY](https://cornell.app.box.com/s/rpl81q6go7s9qq0nm7ndw2tw7h-fh8079/folder/45111358461CU)
-These images can be used to represent groups of researchers and academics going about their work.
-
-[STUDENTS](https://cornell.app.box.com/s/rpl81q6go7s9qq0nm7ndw2tw7h-fh8079/folder/118875861190CU: )
-These images can be used to represent graduate students and younger arXiv users.
-
-[CAMPUS](https://cornell.app.box.com/s/rpl81q6go7s9qq0nm7ndw2tw7h-fh8079/folder/45111410232)
-Here you can find images of the Cornell Tech campus to reinforce arXiv’s stability and create a sense of place.
+[LIBRARY OF CONGRESS ONLINE CATALOG](https://www.loc.gov/pictures/collections/)
+Within this vast image collection can be found free and unlicensed historical images related to scientific discovery.

--- a/source/brand/index.md
+++ b/source/brand/index.md
@@ -12,13 +12,17 @@ Researchers depend on arXiv. Many authors have their life’s work hosted on the
     <img src="images/brand-icon-pillars.jpg" role="representation">
     <span>Brand Pillars</span>
   </a></div>
-  <div class="card"><a href="colors.html">
-    <img src="images/brand-icon-colors.jpg" role="representation">
-    <span>Colors</span>
+  <div class="card"><a href="brand-guidelines.html">
+    <img src="images/brand-icon-guidelines.jpg" role="representation">
+    <span>Logo Use</span>
   </a></div>
   <div class="card"><a href="logos.html">
     <img src="images/brand-icon-logos.jpg" role="representation">
     <span>Logos</span>
+  </a></div>
+  <div class="card"><a href="colors.html">
+    <img src="images/brand-icon-colors.jpg" role="representation">
+    <span>Colors</span>
   </a></div>
   <div class="card"><a href="tagline.html">
     <img src="images/brand-icon-tagline.jpg" role="representation">
@@ -47,9 +51,5 @@ Researchers depend on arXiv. Many authors have their life’s work hosted on the
   <div class="card"><a href="swag.html">
     <img src="images/brand-icon-swag.jpg" role="representation">
     <span>Merchandise</span>
-  </a></div>
-  <div class="card"><a href="guidelines.html">
-    <img src="images/brand-icon-guidelines.jpg" role="representation">
-    <span>Guidelines</span>
   </a></div>
 </div>

--- a/source/brand/logos.md
+++ b/source/brand/logos.md
@@ -10,7 +10,16 @@ Using our logo consistently over time will build up rich layers of meaning with 
 
 > **The logo should not be altered in any way, redrawn, used in an unspecified color or reproduced on a background that will impair its visual recognition.** Use of the name arXiv and associated logos, web addresses, and colors are only allowed with explicit written permission from the arXiv management team.
 
-[Download assets from our logo library](https://cornell.box.com/v/arxiv-logo-assets). *Are you a third party looking to use our logos in your product or materials?* Read our [brand use guidelines](brand-guidelines.html) first.
+
+##Download arXiv logo assets
+*Are you a third party looking to use our logos in your product or materials?* Read our [logo and brand use guidelines](brand-guidelines.html) first. If your project and usage needs meet the criteria outlined in our use guidelines, you may download the style and format you need below:
+
+| Logo style  | Image      | Download links                          |
+| ----------- | --------------- | ------------------------------------ |
+| Primary Logo | ![arXiv primary logo](images/brand-logo-primary.jpg){.mkd-img-thumb} |  [SVG](https://cornell.box.com/v/arxiv-logo-svg){ target='_blank'}, [JPG](https://cornell.box.com/v/arxiv-logo-jpg){target='_blank'}, [PNG](https://cornell.box.com/v/arxiv-logo-png){target='_blank'} |
+| Large Logomark | ![arXiv logomark](images/brand-logomark-primary-large.jpg){.mkd-img-thumb}  | [SVG](https://cornell.box.com/v/arxiv-logomark-svg){target='_blank'}, [JPG](https://cornell.box.com/v/arxiv-logomark-jpg){target='_blank'}, [PNG](https://cornell.box.com/v/arxiv-logomark-png){target='_blank'} |
+| Small Logomark   |  ![arXiv logomark](images/brand-logomark-primary.jpg){.mkd-img-thumb} | [SVG](https://cornell.box.com/v/arxiv-logomark-small-svg){target='_blank'}, [JPG](https://cornell.box.com/v/arxiv-logomark-small-jpg){target='_blank'}, [PNG](https://cornell.box.com/v/arxiv-logomark-small-png){target='_blank'} |
+| Alternate Logos   |   | [Full Logo Library](https://cornell.box.com/v/arxiv-logo-assets) |
 
 ##Primary Logo
 The primary arXiv logo is our default mark seen in most applications. It showcases two primary brand colors: Dark Grey and Cornell Red.

--- a/source/help/ancillary_files.md
+++ b/source/help/ancillary_files.md
@@ -7,7 +7,7 @@ time. They are only supported for submissions with TeX/PDFLaTeX source files.**
 
 
 arXiv is primarily an [archive and distribution service for research
-articles](primer.md). There are limited facilities for including ancillary
+articles](../about/index.md). There are limited facilities for including ancillary
 files with articles. Such ancillary
 files might include:
 
@@ -23,7 +23,7 @@ Submission of ancillary files
 -----------------------------
 
 Ancillary files are included with an arXiv submission by placing them in
-a directory `anc` at the root of your .tar.gz or .zip submission package. 
+a directory `anc` at the root of your .tar.gz or .zip submission package.
 This is done in the "Add Files" step of the submission process.
 
 For example, if
@@ -36,7 +36,7 @@ submission package might be:
 ```
 Ancillary files are stored with a particular version of an article and
 thus cannot be changed independently from the article. Different
-ancillary files may appear with each version. 
+ancillary files may appear with each version.
 
 Display and download
 --------------------

--- a/source/help/api/index.md
+++ b/source/help/api/index.md
@@ -4,27 +4,27 @@ title: arXiv API Access
 
 # arXiv API Access
 
-arXiv offers public API access in order to maximize its openness and interoperability. Many projects utilize this option without becoming official [arXivLabs collaborations](https://labs.arxiv.org). 
+arXiv offers public API access in order to maximize its openness and interoperability. Many projects utilize this option without becoming official [arXivLabs collaborations](https://labs.arxiv.org).
 
-**Commercial projects** that utilize arXiv’s [public APIs](basics.md) or other [bulk data pipelines](../../help/bulk_data.md) are requested to contact arXiv at [nextgen@arxiv.org](mailto:nextgen@arxiv.org), review [arXiv's brand guidelines](../../about/brand.md), sign a memorandum of understanding, and consider becoming an [arXiv affiliate](../../about/funding.md) before embarking on the project. This includes any project created as a product for sale.
+**Commercial projects** that utilize arXiv’s [public APIs](basics.md) or other [bulk data pipelines](../../help/bulk_data.md) are requested to contact arXiv at [nextgen@arxiv.org](mailto:nextgen@arxiv.org), review [arXiv's brand use guidelines](../../brand/index.md), sign a memorandum of understanding, and consider becoming an [arXiv affiliate](../../about/funding.md) before embarking on the project. This includes any project created as a product for sale.
 
 
 **Independent, noncommercial, and open access projects** that…
 
-1. utilize arXiv’s public APIs 
-2. do not require assistance from arXiv, and 
+1. utilize arXiv’s public APIs
+2. do not require assistance from arXiv, and
 3. do not use the names “arXiv”, “arXiv.org”, “arXiv Labs”, “arXivLabs” or associated logos, web addresses and colors
 4. are free, open access, and/or intended for research or educational purposes
 
 ...are considered entirely independent from arXiv. However, we do request that you acknowledge arXiv data usage with this statement: “Thank you to arXiv for use of its open access interoperability.”
 
-**For all API users**, 
+**For all API users**,
 
 - Familiarize yourself with arXiv’s [API Terms of Use](tou.md).
-- Review the [API Basics](basics.md) and the [API User Manual](user-manual.md). 
+- Review the [API Basics](basics.md) and the [API User Manual](user-manual.md).
 - Acknowledge arXiv data usage with this statement on your product: “Thank you to arXiv for use of its open access interoperability.”
 - Do not brand your project with arXiv’s names (“arXiv”, “arXiv.org”, “arXiv Labs”, “arXivLabs”) or use associated logos, web addresses, and colors in a manner that implies arXiv’s endorsement of the project.
-- Check out the arXiv [API user community](basics.md#community) to learn, ask questions, and share information about your project. 
-- Review these additional resources about arXiv’s interoperability: [arXiv’s identifier scheme](../../help/arxiv_identifier_for_services.md), [bulk data access information](../../help/bulk_data.md), and the [Open Archives Initiative](../../help/oa/index.md). 
+- Check out the arXiv [API user community](basics.md#community) to learn, ask questions, and share information about your project.
+- Review these additional resources about arXiv’s interoperability: [arXiv’s identifier scheme](../../help/arxiv_identifier_for_services.md), [bulk data access information](../../help/bulk_data.md), and the [Open Archives Initiative](../../help/oa/index.md).
 
 Does your project positively benefit the arXiv community and require significant assistance from arXiv staff? If so, learn more about how to apply to become an [arXivLabs collaborator](https://labs.arxiv.org).

--- a/source/help/api/user-manual.md
+++ b/source/help/api/user-manual.md
@@ -653,12 +653,12 @@ include:
     ([example](#perl_simple_example))
 
 -   [Python](http://www.python.org) (via
-    [urllib](http://docs.python.org/lib/module-urllib.html))
+    [urllib](https://docs.python.org/3/library/index.html))
     ([example](#python_simple_example))
 
 -   [Ruby](http://www.ruby-lang.org) (via
-    [uri](http://www.ruby-doc.org/stdlib/libdoc/uri/rdoc/) and
-    [net/http](http://www.ruby-doc.org/stdlib/libdoc/net/http/rdoc/index.html))
+    [uri](https://ruby-doc.org/stdlib-2.5.1/libdoc/uri/rdoc/URI.html) and
+    [net::http](https://ruby-doc.org/stdlib-2.7.0/libdoc/net/http/rdoc/Net/HTTP.html))
     ([example](#ruby_simple_example))
 
 -   [PHP](http://www.php.net) (via file\_get\_contents())
@@ -977,6 +977,5 @@ Feed](#atom_feed_outline).
 
 ### 5.3. Subject Classifications
 
-For the complete list of arXiv subject classifications, please visit the 
-[taxonomy](https://arxiv.org/category_taxonomy) page. 
-
+For the complete list of arXiv subject classifications, please visit the
+[taxonomy](https://arxiv.org/category_taxonomy) page.

--- a/source/help/author_identifiers.md
+++ b/source/help/author_identifiers.md
@@ -79,4 +79,4 @@ identifier](https://arxiv.org/set_author_id)** to use with the services listed a
 -   The current opt-in to create an arXiv author identifier is done
     through the [create an author identifier](https://arxiv.org/set_author_id) page,
     current status for any account is shown on the [user account
-    page](/auth "arXiv user account page").
+    page](https://arxiv.org/auth).

--- a/source/help/bulk_data/index.md
+++ b/source/help/bulk_data/index.md
@@ -1,6 +1,6 @@
 #Bulk Access Overview
 
-arXiv is an open access research sharing platform and access to bulk data is also open, with certain stipulations. Thank you in advance for following arXiv’s [API Terms of Use](help/api/tou.md), brand guidelines, and licenses of content posted to arXiv.
+arXiv is an open access research sharing platform and access to bulk data is also open, with certain stipulations. Thank you in advance for following arXiv’s [API Terms of Use](../../help/api/tou.md), brand guidelines, and licenses of content posted to arXiv.
 
 The metadata options are:
 
@@ -11,7 +11,7 @@ The metadata options are:
 Full text options are:
 
 - [AWS](../../help/bulk_data_s3.md) for PDF and or (La)TeX source files
-- [Kaggle](https://www.kaggle.com/Cornell-University/arxiv.md) for PDF
+- [Kaggle](https://www.kaggle.com/Cornell-University/arxiv) for PDF
 - [Crawling our export service](../../help/bulk_data.md#harvest)
     - This is recommended for new content or subset of content. Otherwise the AWS or Kaggle data sets are preferred.
 

--- a/source/help/bulk_data_s3.md
+++ b/source/help/bulk_data_s3.md
@@ -46,9 +46,9 @@ located in the Eastern US (N. Virginia) region.
 
 PDFs are available on S3 in the `arxiv` requester pays bucket. They are
 grouped into `.tar` files of \~500MB each (which we've found is a good
-size chunk). The complete set of files as of December 2022 is about 5.4 TB, 
-with an estimated growth rate of around 100 GB per month, which we expect 
-will increase as the [submission rate](/stats/monthly_submissions) increases 
+size chunk). The complete set of files as of December 2022 is about 5.4 TB,
+with an estimated growth rate of around 100 GB per month, which we expect
+will increase as the [submission rate](https://arxiv.org/stats/monthly_submissions) increases 
 over time.
 Examples keys for these files with the `arxiv` bucket are:
 

--- a/source/help/cs/index.md
+++ b/source/help/cs/index.md
@@ -4,11 +4,11 @@ Welcome to the Computing Research Repository (CoRR) in arXiv. The Computer Scien
 
 You can view the subject category descriptions and browse papers from the [main CS archive page](https://arxiv.org/archive/cs). New readers and authors to arXiv should see our help pages for [registration](../registerhelp.md), [submission](../submit.md) and [subscription](../subscribe.md).
 
-The [moderators for cs are listed here](/moderators#cs).
+The [moderators for cs are listed here](https://arxiv.org/moderators/#cs).
 
 ### CoRR Advisory Committee
 
-The advisory committee members serve as consultants to Cornell University and to the arXiv [Scientific Advisory Board](../about/people/scientific_ad_board.md). All arXiv policy decisions are ultimately made by Cornell University.
+The advisory committee members serve as consultants to Cornell University and to the arXiv [Scientific Advisory Board](../../about/people/scientific_ad_board.md). All arXiv policy decisions are ultimately made by Cornell University.
 
 - Krzysztof Apt, CWI, Amsterdam  
 - Ron Boisvert, NIST  

--- a/source/help/find.md
+++ b/source/help/find.md
@@ -3,7 +3,7 @@
 ## Search
 Enter a few title words and/or author names and/or abstract words into
 the "**Search or Article-id**" box in the top right of most pages
-(including this one) or you can use the [Advanced Search](bitmap/advanced.md)
+(including this one) or you can use the [Advanced Search](./bitmap/advanced.md)
 
 ## If you know the identifier
 All arXiv submissions are assigned a unique identifier of the form

--- a/source/help/find/index.md
+++ b/source/help/find/index.md
@@ -3,7 +3,7 @@
 ## Search
 Enter a few title words and/or author names and/or abstract words into
 the "**Search or Article-id**" box in the top right of most pages
-(including this one) or you can use the [Advanced Search](bitmap/advanced.md)
+(including this one) or you can use the [Advanced Search](../bitmap/advanced.md)
 
 ## If you know the identifier
 All arXiv submissions are assigned a unique identifier of the form
@@ -18,4 +18,4 @@ identifier as `http://arxiv.org/abs/<identifier>`. For example,
      http://arxiv.org/abs/0705.0123
 
 From the abstract page you will be able to choose your preferred format
-for [downloading and viewing](view.md) the paper.
+for [downloading and viewing](../view.md) the paper.

--- a/source/help/gzip.md
+++ b/source/help/gzip.md
@@ -1,0 +1,23 @@
+# Gzipped Files
+
+In order to save network bandwidth and disk space, submissions are
+compressed. The archive uses the [GNU](https://www.gzip.org/)
+*gzip* utility, which is free software.
+
+See our [detailed utilities help](utilities#taretc) for instructions on
+obtaining gzip.
+
+Along with gzip you will always find *gunzip*, which decompresses
+compressed files; gunzip can uncompress files in several different
+compression formats.
+
+Gzipped files usually have a `.gz` extension.
+
+To gzip a file on the Unix command line do the following:
+
+      > gzip filename
+
+This will create a compressed file called `filename.gz` and delete the
+original uncompressed version. To uncompress the file, do
+
+      > gunzip filename.gz

--- a/source/help/index.md
+++ b/source/help/index.md
@@ -53,6 +53,5 @@ THIS IS A TEST from Brian C. Please ignore.
 - [Usage statistics](stats/index.md)
 - [Obsolete Macros](macro_list.md)
 - [MathJax](mathjax.md)
-- [SSL Support in arXiv](ssl.md)
 
 If you could not find an answer to your question, please [contact our User Support team](contact.md#contacting-arxiv).

--- a/source/help/otherformats.md
+++ b/source/help/otherformats.md
@@ -1,0 +1,5 @@
+# Submission of PDF
+
+If your paper was written in a word processor (e.g. Word, WordPerfect), we require you to submit it in either the PDF.
+
+See our help pages on considerations for [submitting PDF](submit_pdf) for more information.

--- a/source/help/replace.md
+++ b/source/help/replace.md
@@ -10,7 +10,7 @@ announced you may select the Unsubmit (![unsubmit
 icon](https://arxiv.org/images/unsubmit.png)) icon next to the submission on your [user
 page](http://arxiv.org/user) to return it to the [incomplete
 status](submit_status.md#incomplete) allowing modification and later
-resubmission via the Update (![update icon](/images/update.png)) icon.
+resubmission via the Update (![update icon](../assets/update.png)) icon.
 
 <span id="consider"></span>
 

--- a/source/help/submit.md
+++ b/source/help/submit.md
@@ -1,7 +1,7 @@
 # Submission Guidelines
 
 
-<span id="guidelines"></span> 
+<span id="guidelines"></span>
 
 While submission to arXiv is free for authors, we do ask authors to carefully prepare their work according to these guidelines. This will improve discoverability of the work and reduce the likelihood of delays before announcement.
 
@@ -42,10 +42,10 @@ Accepted submission formats
 
 -   [(La)TeX, AMS(La)TeX, PDFLaTeX](submit_tex.md)
 -   [PDF](submit_pdf.md)
--   [HTML with JPEG/PNG/GIF images](submit_html.md)
+-   [HTML with JPEG/PNG/GIF images](submit_index.md)
 
 Our goal is to store articles in formats that are highly portable and
-stable over time. Currently, the best choice is TeX/LaTeX. 
+stable over time. Currently, the best choice is TeX/LaTeX.
 
 We do not accept [dvi, PS, or PDF created
 from TeX/LaTeX source](faq/whytex.md), and we
@@ -58,9 +58,9 @@ do not accept scanned documents, regardless of format.
 Accepted figure formats:
 
 -   PostScript (PS, EPS) &mdash; requires [LaTeX processing](submit_tex.md#latex)
--   JPEG, GIF, PNG or PDF figures &mdash; requires [PDFLaTeX processing](submit_tex.md#pdflatex) 
+-   JPEG, GIF, PNG or PDF figures &mdash; requires [PDFLaTeX processing](submit_tex.md#pdflatex)
 
-We do not accept submissions with omitted figures, even if you provide links to view figures externally. 
+We do not accept submissions with omitted figures, even if you provide links to view figures externally.
 
 If you submit figures with your (La)TeX source, use standard macro
 packages (e.g., the `graphics` and `graphicx` packages) to have
@@ -112,9 +112,9 @@ and the processed files, and correct any errors. [Contact arXiv
 administrators](contact.md) for help.
 
 If you discover an error after submission but before public announcement,
-select the "Unsubmit" (![unsubmit icon](/images/unsubmit.png)) icon
+select the "Unsubmit" (![unsubmit icon](../assets/unsubmit.png)) icon
 next to the submission on your [user page](http://arxiv.org/user). This will
-return it to [incomplete status](submit_status.md#incomplete) and allow you to 
+return it to [incomplete status](submit_status.md#incomplete) and allow you to
 modify your files and resubmit.
 
 Unsubmitting an article takes the article out of the processing queue, and announcement will be scheduled based on the later resubmission time. See the schedule of [availability](availability.md).
@@ -139,4 +139,4 @@ for an erratum. Instead, [replace](replace.md) the original submission.
 
 ## Availability of submissions
 
-For more information see our [public submission availability page](availability.md). 
+For more information see our [public submission availability page](availability.md).

--- a/source/help/submit/index.md
+++ b/source/help/submit/index.md
@@ -39,7 +39,7 @@ Accepted submission formats
 (in order of preference):
 
 -   [(La)TeX, AMS(La)TeX, PDFLaTeX](../submit_tex.md)
--   [PDF](submit_pdf.md)
+-   [PDF](../submit_pdf.md)
 -   [HTML with JPEG/PNG/GIF images](../submit_html.md)
 
 Our goal is to store articles in formats that are highly portable and
@@ -107,7 +107,7 @@ searching.
 Before you make the final "Submit Article" step in the submission
 process, be sure to carefully check the title and abstract (metadata)
 and the processed files, and correct any errors. [Contact arXiv
-administrators](contact.md) for help.
+administrators](../contact.md) for help.
 
 If you discover an error after submission but before public announcement,
 select the "Unsubmit" (![unsubmit icon](../images/unsubmit.png)) icon

--- a/source/help/submit_tex.md
+++ b/source/help/submit_tex.md
@@ -101,7 +101,7 @@ If you use standard identifiers of the form 1510.00322, arXiv:1510.00322, 0901.0
 > `\bedim{upsilon}
 > C.T.H. Davies {\em et al.}, Phys. Rev {\bf D} 50 (1994) 6963, hep-lat/9406017.`
 
-Do not include extraneous font commands, spaces, tildes, braces or line-breaks within the e-print identifier: this will cause your references to be missed by automated extraction software. See also notes about [references to and in arXiv documents](faq/references.md) and [collection of references at INSPIRE](http://inspirehep.net/). Use of e-print identifiers is a significant aid to the INSPIRE database. It also facilitates automatic network hyperlinks of references from within papers.
+Do not include extraneous font commands, spaces, tildes, braces or line-breaks within the e-print identifier: this will cause your references to be missed by automated extraction software. See also notes about [references to and in arXiv documents](faq/references.md) and [collection of references at INSPIRE](https://inspirehep.net/). Use of e-print identifiers is a significant aid to the INSPIRE database. It also facilitates automatic network hyperlinks of references from within papers.
 
 If you use BibTeX there are some BibTeX styles which support e-print identifiers (see [BibTeX and Eprints](hypertex/bibstyles/index.md)).
 

--- a/source/new/index.md
+++ b/source/new/index.md
@@ -751,7 +751,7 @@ Note that with the new submission system permanent identifiers are assigned only
 
 21 Jan 2010
 
-**Collaborative Support Plan Announced:** Cornell University Library is beginning an effort to expand funding sources for arXiv to ensure its stability and continued development. We are working to establish a collaborative business model that will engage the institutions that benefit most from arXiv — academic institutions, research centers and government labs — by asking them for voluntary contributions. Our plans are outlined in the [press release](http://news.library.cornell.edu/news/arxiv) and in the [arXiv support](../help/support.md).
+**Collaborative Support Plan Announced:** Cornell University Library is beginning an effort to expand funding sources for arXiv to ensure its stability and continued development. We are working to establish a collaborative business model that will engage the institutions that benefit most from arXiv — academic institutions, research centers and government labs — by asking them for voluntary contributions. Our plans are outlined in the [press release](http://news.library.cornell.edu/news/arxiv) and in the [arXiv support](../about/governance.md).
 
 #### Nov 2009
 


### PR DESCRIPTION
This PR fixes *most* internal broken links.

Pending are a number of broken links under /about/reports (mostly for older report files), and many external links.