### PR TITLE
Update to help/faq/dvips to reflect actual defaults in practice

### DIFF
--- a/source/help/faq/dvips.md
+++ b/source/help/faq/dvips.md
@@ -1,6 +1,6 @@
 # Papersize/Layout Problems: Margins are Different and/or Text is Truncated
 
-**Note:** prior to arXiv's [TeXLive 2020 upgrade](texlive.md), all submissions were forced into US Letter page dimensions. This is no longer the current practice, however the information below may still be of use for diagnosing odd behavior around local printing problems. 
+**Note:** prior to arXiv's [TeXLive 2020 upgrade](texlive.md), all submissions were forced into US Letter page dimensions. The current practice is to allow other paper sizes when explicitly stated, with `letterpaper` being the default page size. The information below may still be of use for diagnosing odd behavior around local display or printing problems. 
 
 There are many possible reasons for a papersize/layout problem. It may
 be due to differences in style files used, variations in layout


### PR DESCRIPTION
The help page indicated that we no longer "force" submissions into `letterpaper` size. While true, if no page size is specified it will default to `letterpaper`, when the author's local installation may have a default page size of `A4`. This change updates the documentation to reflect this change. 