### PR TITLE
Removes information about YYMM substitutions in tex source

### DIFF
--- a/source/help/submit_tex.md
+++ b/source/help/submit_tex.md
@@ -31,8 +31,6 @@ You must submit any figures that go along with your paper. We recommend that you
 
 _Note:_ arXiv recommends against using the `\today` macro in the standard `\date` field. Because pdf are occasionally rebuilt this date will change and may cause confusion, as outlined in our [FAQ page for this topic](faq/today.html). To avoid this issue, do not use it unless you are comfortable with the displayed date changing periodically. 
 
-_Note:_ In the past, it was possible to include a generic arXiv identifier in the TeX source that the processor would automatically translate into the identifier of the current submission. This practice is no longer necessary, nor supported. All TeX-type submissions receive the arXiv watermark, including the canonical identifier, version number, primary classification, and a link back to the correct version on the arXiv site. Again, `arch-ive/yymmnnn` (and, by extension, `yymm.nnnnn`) will _not_ be translated to the correct identifier for your submission.
-
 <span id="latex"></span>
 
 ### Considerations for (La)TeX submissions


### PR DESCRIPTION
Currently the tex submission help page states: 

Note: In the past, it was possible to include a generic arXiv identifier in the TeX source that the processor would automatically translate into the identifier of the current submission. This practice is no longer necessary, nor supported. All TeX-type submissions receive the arXiv watermark, including the canonical identifier, version number, primary classification, and a link back to the correct version on the arXiv site. Again, arch-ive/yymmnnn (and, by extension, yymm.nnnnn) will not be translated to the correct identifier for your submission.

This functionality has not been available since the identifier changeover to the `YYMM` format in 2007. This PR removes this from the tex help page.