### PR TITLE
re-adds OSTP letter

### DIFF
--- a/source/about/OSTP-04-11-2023.md
+++ b/source/about/OSTP-04-11-2023.md
@@ -1,5 +1,7 @@
 # arXiv OSTP memorandum response
 
+*April 11, 2023*
+
 The recent Office of Science and Technology Policy “Nelson Memorandum” on “Ensuring Free, Immediate, and Equitable Access to Federally Funded Research”<sup>1</sup> is a welcome affirmation of the public right to access government funded research results, including publication of articles describing the research, and the data behind the research.  The policy is likely to increase access to new and ongoing research, enable equitable access to the outcome of publicly funded research efforts, and enable and accelerate more research. Improved immediate access to research results may provide significant general social and economic benefits to the public.
 
 Funding Agencies can expedite public access to research results through the distribution of electronic preprints of results in open repositories, in particular existing preprint distribution servers such as arXiv,<sup>2</sup> bioRxiv,<sup>3</sup> and medRxiv.<sup>4</sup> Distribution of preprints of research results enables rapid and free accessibility of the findings worldwide, circumventing publication delays of months, or, in some cases, years. Rapid circulation of research results expedites scientific discourse, shortens the cycle of discovery and accelerates the pace of discovery.<sup>5</sup>

--- a/source/about/OSTP.md
+++ b/source/about/OSTP.md
@@ -1,0 +1,22 @@
+# arXiv OSTP memorandum response
+
+The recent Office of Science and Technology Policy “Nelson Memorandum” on “Ensuring Free, Immediate, and Equitable Access to Federally Funded Research”<sup>1</sup> is a welcome affirmation of the public right to access government funded research results, including publication of articles describing the research, and the data behind the research.  The policy is likely to increase access to new and ongoing research, enable equitable access to the outcome of publicly funded research efforts, and enable and accelerate more research. Improved immediate access to research results may provide significant general social and economic benefits to the public.
+
+Funding Agencies can expedite public access to research results through the distribution of electronic preprints of results in open repositories, in particular existing preprint distribution servers such as arXiv,<sup>2</sup> bioRxiv,<sup>3</sup> and medRxiv.<sup>4</sup> Distribution of preprints of research results enables rapid and free accessibility of the findings worldwide, circumventing publication delays of months, or, in some cases, years. Rapid circulation of research results expedites scientific discourse, shortens the cycle of discovery and accelerates the pace of discovery.<sup>5</sup>
+
+Distribution of research findings by preprints, combined with curation of the archive of submissions, provides universal access for both authors and readers in perpetuity. Authors can provide updated versions of the research, including “as accepted,” with the repositories openly tracking the progress of the revision of results through the scientific process. Public access to the corpus of machine readable research manuscripts provides innovative channels for discovery and additional knowledge generation, including links to the data behind the research, open software tools, and supplemental information provided by authors.
+
+Preprint repositories support a growing and innovative ecosystem for discovery and evaluation of research results, including tools for improved accessibility and research summaries. Experiments in open review and crowdsourced commenting can be layered over preprint repositories, providing constructive feedback and alternative models to the increasingly archaic process of anonymous peer review.
+
+Distribution of research results by preprints provides a well tested path for immediate, free, and equitable access to research results. Preprint archives can support and sustain an open and innovative ecosystem of tools for research discovery and verification, providing a long term and sustainable approach for open access to publicly funded research.
+
+---
+<sup>1</sup>[White House OSTP Public Access Memo](https://www.whitehouse.gov/wp-content/uploads/2022/08/08-2022-OSTP-Public-Access-Memo.pdf)
+
+<sup>2</sup>[arXiv website](https://arxiv.org/)
+
+<sup>3</sup>[bioRxiv website](https://www.biorxiv.org/)
+
+<sup>4</sup>[medRxiv website](https://www.medrxiv.org/)
+
+<sup>5</sup>[NIH Preprint Pilot](https://www.nlm.nih.gov/news/NIH_Preprint_Pilot_Accelerates_Expands_Discovery_Research_Results.html), ["The Pace of Artificial Intelligence Innovations: Speed, Talent, and Trial-and-Error"](https://arxiv.org/pdf/2009.01812.pdf)


### PR DESCRIPTION
This PR re-adds the OSTP letter that was removed due to an unforeseen delay in the announcement plan. We can deploy it when ready.