### PR TITLE
remove nextgen@ email address and related references.

### DIFF
--- a/source/about/accessibility.md
+++ b/source/about/accessibility.md
@@ -39,7 +39,6 @@ After extensive research with diverse arXiv users, we have shared our findings i
 
 A fully accessible arXiv is important, meaningful, and ambitious. Significant development resources and user testing are needed to reach our targets and the arXiv community may wish to help in the following ways:
 
-- Learn more about contributing development time to making arXiv TeX research papers accessible by emailing nextgen@arxiv.org.
 - [Donate](https://arxiv.org/about/give) and support creation of an accessible arXiv.
 - Learn about [arXiv Labs](https://labs.arxiv.org) and developing tools that benefit the arXiv community.
 - Join the [arXiv usability testing list](user-testing.md) and share your feedback and insights.

--- a/source/about/people/developers.md
+++ b/source/about/people/developers.md
@@ -27,8 +27,6 @@ the arXiv codebase:
 - Robert Stojnic ([rstojnic](https://github.com/rstojnic))
 
 Please see our [guidelines for
-contributors](https://github.com/arXiv/.github/blob/master/CONTRIBUTING.md), or
-contact nextgen@arxiv.org, for more information about contributing to arXiv
-software development.
+contributors](https://github.com/arXiv/.github/blob/master/CONTRIBUTING.md) for more information about contributing to arXiv software development.
 
 We are excited to be experimenting with a small number of collaborators on arXiv Labs projects that add value for our stakeholders and advance research. [Learn more about arXiv Labs](https://labs.arxiv.org) and ways to get involved.

--- a/source/brand/brand-guidelines.md
+++ b/source/brand/brand-guidelines.md
@@ -8,8 +8,8 @@ Using our logo consistently is important to present a unified message to the wor
 The arXiv logo is a registered trademark and the legal property of arXiv and Cornell University, protected against unauthorized use. Our logo is ready to help us share a consistent, intentional, and meaningful message about who we are with the world.
 
 ##General guidelines that cover all logo use cases
-1. Use of the name arXiv and associated logos, web addresses, and colors are only allowed with explicit written permission from the arXiv management team.
-2. If use is allowed, display of the arXiv logo should always follow the visual layout rules as stated in the arXiv brand guide.
+1. Use of the name arXiv and associated logos, web addresses, and colors are only allowed for the purpose of acknowledging use of arXiv's API or data from the arXiv corpus.
+2. If the logo is displayed for the purposes of acknowledgement, follow the visual layout rules as stated in the arXiv brand guide.
 3. The logo should never be altered in any way, redrawn, used in an unspecified color, or reproduced on a background that will impair its visual recognition.
 4. The use of the name “arXiv” or “arXiv.org,” in non-arXiv organization names or projects that imply or tend to imply some official connection with arXiv, is prohibited.
 5. Except as specifically authorized in writing, use of arXiv’s name and marks in advertising and other promotional vehicles is prohibited when such use is likely to be perceived as an endorsement, even if such an endorsement is not the intention of the person or organization seeking to use arXiv’s name or marks.
@@ -19,7 +19,7 @@ The arXiv logo is a registered trademark and the legal property of arXiv and Cor
 
 ###For products that use the arXiv API
 1. Acknowledge arXiv data usage with this statement on your product: ​“Thank you to arXiv for use of its open access interoperability. This [service/ product] was not reviewed or approved by, nor does it necessarily express or reflect the policies or opinions of, arXiv.”
-2. Typically logo usage is not granted for API use. If you think your project is an exception you can always inquire at ​nextgen@arxiv.org​.
+2. Logo use is limited to acknowledgement of the user of arXiv's API or data from the arXiv corpus.
 3. The use of the name “arXiv” or “arXiv.org,” in non-arXiv organization names implying or tending to imply some official connection with arXiv, is prohibited.
 
 ###For members & affiliates

--- a/source/help/api/index.md
+++ b/source/help/api/index.md
@@ -6,8 +6,7 @@ title: arXiv API Access
 
 arXiv offers public API access in order to maximize its openness and interoperability. Many projects utilize this option without becoming official [arXivLabs collaborations](https://labs.arxiv.org).
 
-**Commercial projects** that utilize arXiv’s [public APIs](basics.md) or other [bulk data pipelines](../../help/bulk_data.md) are requested to contact arXiv at [nextgen@arxiv.org](mailto:nextgen@arxiv.org), review [arXiv's brand use guidelines](../../brand/index.md), sign a memorandum of understanding, and consider becoming an [arXiv affiliate](../../about/funding.md) before embarking on the project. This includes any project created as a product for sale.
-
+**Commercial projects** that utilize arXiv’s APIs should review relevant documentation first. Read about our [public APIs](basics.md) or other [bulk data pipelines](../../help/bulk_data.md), review [arXiv's brand use guidelines](../../brand/index.md), and consider becoming an [arXiv affiliate](../../about/funding.md) before embarking on the project. This includes any project created as a product for sale.
 
 **Independent, noncommercial, and open access projects** that…
 

--- a/source/labs/showcase.md
+++ b/source/labs/showcase.md
@@ -129,4 +129,4 @@ ___
 
 
 
-We are grateful to the [volunteer developers](https://arxiv.org/about/people/developers) who contribute to the arXiv codebase and invite you to get involved. Please see the [arXivLabs submission portal](https://arxiv-org.atlassian.net/servicedesk/customer/portal/6) and [guidelines for contributors](https://github.com/arXiv/.github/blob/master/CONTRIBUTING.md), or contact nextgen@arxiv.org, for more information about contributing to arXivLabs.
+We are grateful to the [volunteer developers](https://arxiv.org/about/people/developers) who contribute to the arXiv codebase and invite you to get involved. Please see the [arXivLabs submission portal](https://arxiv-org.atlassian.net/servicedesk/customer/portal/6) and [guidelines for contributors](https://github.com/arXiv/.github/blob/master/CONTRIBUTING.md) for more information about contributing to arXivLabs.

--- a/source/labs/showcase.md
+++ b/source/labs/showcase.md
@@ -129,4 +129,4 @@ ___
 
 
 
-We are grateful to the [volunteer developers](https://arxiv.org/about/people/developers) who contribute to the arXiv codebase and invite you to get involved. Please see the [arXivLabs submission portal](https://arxiv-org.atlassian.net/servicedesk/customer/portal/6) and [guidelines for contributors](https://github.com/arXiv/.github/blob/master/CONTRIBUTING.md) for more information about contributing to arXivLabs.
+We are grateful to the [volunteer developers](https://info.arxiv.org/about/people/developers.html) who contribute to the arXiv codebase and invite you to get involved. Please see the [arXivLabs submission portal](https://arxiv-org.atlassian.net/servicedesk/customer/portal/6) and [guidelines for contributors](https://github.com/arXiv/.github/blob/master/CONTRIBUTING.md) for more information about contributing to arXivLabs.


### PR DESCRIPTION
This PR removes references to nextgen@arxiv.org from the info.arxiv.org site. It also makes minor text changes related to those email references.