### PR TITLE
Adds Wed. June 14 as known no-mailing day

### DIFF
--- a/source/help/availability.md
+++ b/source/help/availability.md
@@ -31,6 +31,7 @@ On the occasion that arXiv defers a mailing (either for locally celebrated holid
 
 ### 2023 Holidays 
 - Mon 16 January 
+- Wed 14 June
 - Mon 19 June
 - Tues 4 July
 - Mon 4 September


### PR DESCRIPTION
Adds Wednesday June 14, 2023 to the list of known holidays. 

https://info.arxiv.org/help/availability.html#2023-holidays

per: https://arxiv-org.atlassian.net/browse/ARXIVCE-338