### PR TITLE
Updates help/authority and help/passwords

### DIFF
--- a/source/help/authority.md
+++ b/source/help/authority.md
@@ -19,7 +19,7 @@ papers they have written or own.
 When you submit a paper, you will automatically be registered as an *owner* of
 that paper. At submission time, we will ask if you are an author, and if you
 say yes, you will automatically be registered as an *author*. Your co-authors
-can become authors by giving them the [paper password](passwords.md) for the
+can become authors by giving them the [paper password](passwords) for the
 paper, which you received in a confirmation e-mail, if you expressed being an
 author of the submitted paper during the submission phase. They can then enter
 the arXiv identifier and paper password on the [claim
@@ -51,4 +51,4 @@ Submitters are responsible for ensuring all co-authors have consented to submiss
 
 ### Falsification of Authorship
 
-Submitters are required to comply with arXiv's [code of conduct](policies/code_of_conduct.md). If you believe there has been an ethical violation such as falsification of authorship, please [contact arXiv user support](https://arxiv.org/support/moderation_help) with a complete explanation. Note that such a claim may require that the admin team open a dialog with the submitter as well. Such a report cannot be used as an "authorship dispute by proxy".
+Submitters are required to comply with arXiv's [code of conduct](policies/code_of_conduct). If you believe there has been an ethical violation such as falsification of authorship, please [contact arXiv user support](https://arxiv.org/support/moderation_help) with a complete explanation. Note that such a claim may require that the admin team open a dialog with the submitter as well. Such a report cannot be used as an "authorship dispute by proxy".

--- a/source/help/authority.md
+++ b/source/help/authority.md
@@ -16,28 +16,27 @@ papers they have written or own.
 
 ## For submitters
 
+When you submit a paper, you will automatically be registered as an *owner* of
+that paper. At submission time, we will ask if you are an author, and if you
+say yes, you will automatically be registered as an *author*. Your co-authors
+can become authors by giving them the [paper password](passwords.md) for the
+paper, which you received in a confirmation e-mail, if you expressed being an
+author of the submitted paper during the submission phase. They can then enter
+the arXiv identifier and paper password on the [claim
+ownership](https://arxiv.org/auth/need-paper-password) form. We recommend that
+you share the paper password with all of the authors of each paper you submit
+and encourage them to register themselves as owners.
 
-When you submit a paper, you will automatically be registered as an
-*owner* of that paper. At submission time, we will ask if you are an
-author, and if you say yes, you will automatically be registered as an
-*author*. Your co-authors can become authors by giving them the [paper
-password](passwords.md) for the paper. They can then enter the arXiv
-identifier and paper password on the [claim
-ownership](https://arxiv.org/auth/need-paper-password) form. We
-recommend that you share the paper password with all of the authors of
-each paper you submit and encourage them to register themselves as
-owners.
-
-If papers you have submitted are
-missing entirely from your [list of papers](https://arxiv.org/user/), you
-should follow the instructions below for *other authors*.
+If papers you have submitted are missing entirely from your [list of
+papers](https://arxiv.org/user/), you should follow the instructions below for
+*other authors*.
 
 If a paper is on your list of papers you own, but you are not registered as an author,
 you can use the [Change Author Status form](https://arxiv.org/auth/change-author-status).
 
 ## For other authors
 
-Since most papers have multiple authors, it is quite likely that you are the author of a paper that you did not submit personally. 
+Since most papers have multiple authors, it is quite likely that you are the author of a paper that you did not submit personally.
 
 ### To claim a paper
 
@@ -50,6 +49,6 @@ If you do not have the paper password you can use the [Request Ownership form](h
 
 Submitters are responsible for ensuring all co-authors have consented to submission of the work to arXiv. Under U.S. copyright law, a single co-author normally has authority to agree to arXiv's non-exclusive distribution license. Submitters to arXiv are expected to follow normal publishing practices for co-authored submissions (i.e. seeking consent and approval from their co-authors and any other required parties). arXiv will not adjudicate authorship disputes surrounding submission or announcement. Concerns should be directed directly to the submitting author's institution. Findings from an institutional investigation may be sent to [arXiv user support](https://arxiv.org/support) by an institutional officer. At that point arXiv will consider what action, if any, may be taken regarding the submission.
 
-### Falsification of Authorship 
+### Falsification of Authorship
 
 Submitters are required to comply with arXiv's [code of conduct](policies/code_of_conduct.md). If you believe there has been an ethical violation such as falsification of authorship, please [contact arXiv user support](https://arxiv.org/support/moderation_help) with a complete explanation. Note that such a claim may require that the admin team open a dialog with the submitter as well. Such a report cannot be used as an "authorship dispute by proxy".

--- a/source/help/passwords.md
+++ b/source/help/passwords.md
@@ -21,12 +21,13 @@ User account passwords:
 Paper passwords:
 ----------------
 
-arXiv now maintains [authority records](authority.md). For any given
-paper, arXiv keeps a list of people who are authorized to make changes
-(these are referred to as **paper owners**). When a paper is first
-submitted to arXiv, the submitter is the one and only owner of the
-paper. See [authority records](https://arxiv.org/help/authority) for
-more information.
+arXiv now maintains [authority records](authority.md). For any given paper,
+arXiv keeps a list of people who are authorized to make changes (these are
+referred to as **paper owners**). When a paper is first submitted to arXiv,
+the submitter is the one and only owner of the paper, and receives a **paper
+password** in the confirmation e-mail related to the paper submission, *if*
+they marked themselves as an author during the submission phase. See
+[authority records](https://arxiv.org/help/authority) for more information.
 
 -   [Claim ownership of a paper using a paper
     password](https://arxiv.org/auth/need-paper-password)

--- a/source/help/passwords.md
+++ b/source/help/passwords.md
@@ -5,29 +5,31 @@ arXiv uses two types of passwords:
 
 -   User account passwords for accessing your user account page
     ([https://arxiv.org/user](https://arxiv.org/user))
--   Paper passwords for claiming ownership of a paper submitted by
+-   Paper passwords for claiming ownership of an announced article submitted by
     co-authors or a proxy
 
 User account passwords:
 -----------------------
 
 -   Details about setting up your account are on our [registration help
-    page.](registerhelp.md)
+    page.](registerhelp)
 -   If you forgot your user account password, please see the [lost
     password form](https://arxiv.org/user/lost_password).
--   If you need help recovering an arXiv user account, please email
-    help@arxiv.org.
+-   If you need help recovering an arXiv user account, please [contact arXiv administrators](/help/contact)for support.
 
 Paper passwords:
 ----------------
 
-arXiv now maintains [authority records](authority.md). For any given paper,
-arXiv keeps a list of people who are authorized to make changes (these are
-referred to as **paper owners**). When a paper is first submitted to arXiv,
-the submitter is the one and only owner of the paper, and receives a **paper
-password** in the confirmation e-mail related to the paper submission, *if*
-they marked themselves as an author during the submission phase. See
-[authority records](https://arxiv.org/help/authority) for more information.
+arXiv maintains [authority records](authority) for the works within our corpus.
+These are the list of author accounts who are authorized to make changes (referred to as the **owner**).
+When an article is first submitted to arXiv, the submitter is the only owner of that work. 
+They receive the **paper password** as part of the announcement e-mail when the final 
+arXiv-id is assigned. See [authority records](authority) for more information regarding 
+how co-authors may become an owner. 
+
+If you have not received the paper password for your article after its announcement, 
+please contact arXiv administration through the [user support portal](http://arxiv.org/support/general_help) to request the password. 
+
 
 -   [Claim ownership of a paper using a paper
     password](https://arxiv.org/auth/need-paper-password)


### PR DESCRIPTION
Updates to clarify how paper passwords are assigned, and how to obtain them when lost. 