### PR TITLE
Adds Angela Gibney to math advisory committee

### DIFF
--- a/source/help/math/index.md
+++ b/source/help/math/index.md
@@ -14,6 +14,7 @@ The advisory committee members serve as consultants to Cornell University and to
 
 - [Doug Arnold](http://www.ima.umn.edu/~arnold/)
 - [Ioana Dumitriu](http://www.math.washington.edu/~dumitriu/)
+- [Angela Gibney] (https://www.angelagibney.org/)
 - [Paul Gunnells (vice-chair)](http://people.math.umass.edu/~gunnells/)
 - [Alex Iosevich](http://www.math.rochester.edu/people/faculty/iosevich/) 
 - [Greg Kuperberg (chair)](http://www.math.ucdavis.edu/~greg/)


### PR DESCRIPTION
https://arxiv-org.atlassian.net/browse/ARXIVCE-495

Per email from Greg Kuperberg:

```
Greg Kuperberg
Subject:Please add Angela Gibney as math arXiv committee member
Sat 7/1/2023 3:27 PM
To: bdc34
Cc: angela gibney
Hello Brian,

The math arXiv advisory committee has voted unanimously to accept Angela Gibney as a new member. 
``` 
