### PR TITLE
Adds redirect into /brand/index from bogus google search result

### DIFF
--- a/source/about/brand.html
+++ b/source/about/brand.html
@@ -1,0 +1,8 @@
+<!DOCTYPE HTML>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="1; url=/brand/index.html">
+    <script>
+      window.location.href = "/brand/index.html"
+    </script>
+    <title>Redirect</title>
+    If you are not redirected automatically, please follow the <a href='/brand/index.html'>link</a>


### PR DESCRIPTION
Per https://arxiv-org.atlassian.net/browse/ARXIVCE-746: 

This URL Is discoverable via web search: https://info.arxiv.org/about/brand.html but does not resolve. It needs to be redirected to: https://info.arxiv.org/brand/index.html