### PR TITLE
PyYAML 6.0 which is released on 2021 does not intall on ARM Macs.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ Pygments==2.13.0
 pymdown-extensions==9.6
 pyparsing==3.0.9
 python-dateutil==2.8.2
-PyYAML==6.0
+PyYAML==6.0.1
 pyyaml_env_tag==0.1
 requests==2.28.1
 six==1.16.0


### PR DESCRIPTION
6.0.1, released on Jul 17, 2023 works on Apple Silicone Macs.