### PR TITLE
About Arixiv index: removed duplicate info

### DIFF
--- a/source/about/index.md
+++ b/source/about/index.md
@@ -13,19 +13,23 @@ Registered users may [submit articles](../help/submit.md) to be announced by arX
 
 ## News
 
-- [arXiv Reports](reports/index.md)
 - [Usage Stats](https://arxiv.org/stats/main)
 - [arXiv Blog](https://blogs.cornell.edu/arxiv)
 - [arXiv Twitter](https://twitter.com/arxiv)
 
-## Funding, Membership, & Giving
+## Funding & Governance
 
 - [Funding Support](funding.md)
-- [Donate to arXiv](donate.md)
+- [Governance](governance.md)
+- [Business Model](reports-financials.md)
+- [Annual Reports and Financials](reports/index.md)
+
+## Membership & Giving
+
 - [Institutional Membership Program](membership.md)
 - [Our Members](ourmembers.md)
 - [Our Supporters](supporters.md)
-
+- [Donate to arXiv](donate.md)
 
 ## Who We Are
 
@@ -46,11 +50,5 @@ Registered users may [submit articles](../help/submit.md) to be announced by arX
 - [Volunteer Moderators](https://arxiv.org/moderators)
 - [Volunteer Developers](people/developers.md)
 - [Join arXiv's User Testing Group](user-testing.md)
-
-
-## General Information
-
-- [Governance](governance.md)
-- [Business Model](reports-financials.md)
-- [Annual Reports and Financials](reports/index.md)
 - [Brand Guide and Logo Usage](../brand/index.md)
+


### PR DESCRIPTION
I removed and condensed some sections on the About arXiv page. 
[https://info.dev.arxiv.org/about/index.html](https://info.dev.arxiv.org/about/index.html)

I removed the General Information section because 'Annual Reports' was duplicative and the rest of it (Governance, Business Model and Brand Guide) could be integrated amongst other sections. 

Under News:
I removed the reports section because those are annual and it's only news annually. I moved reports to Funding (see below)

Funding, Membership, & Giving changed it to 'Funding & Governance'
I removed membership and giving.
Under this new header there is funding, governance, business model, annual reports.

Created Membership & Giving:
Under which I placed Institutional Membership Program, Our Members, Our supporters and Donate to arXiv.

Under Who We Are:
I added Brand Guide and logos because the brand guide visually describes who we are. 


