### PR TITLE
LaTeX Markup BP submission link

### DIFF
--- a/source/help/submit.md
+++ b/source/help/submit.md
@@ -41,6 +41,7 @@ Accepted submission formats
 (in order of preference):
 
 -   [(La)TeX, AMS(La)TeX, PDFLaTeX](submit_tex.md)
+    - [(La)TeX Markup Best Practices for Successful HTML Papers](submit_latex_best_practices.md)
 -   [PDF](submit_pdf.md)
 -   [HTML with JPEG/PNG/GIF images](submit_index.md)
 


### PR DESCRIPTION
I linked to the best practices guide on the Submissions Guidelines page under Formats for text of submission. See screenshot below. This seems to be the most relevant/relatable spot to link this. Please share your feedback. Thanks!
_____

<img width="740"  alt="Screenshot 2023-11-20 at 4 33 11 PM" src="https://github.com/arXiv/arxiv-docs/assets/7672738/36c5d7b9-f54f-4c7f-8fee-7b68972590f7">
