### PR TITLE
Submission agreement 202303

### DIFF
--- a/source/SUMMARY.md
+++ b/source/SUMMARY.md
@@ -64,7 +64,6 @@
      * [Privacy policy](help/policies/privacy_policy.md)
      * [Identity, affiliation, and registration](help/registerhelp.md)
      * [Submission terms and agreement](help/policies/submission_agreement.md)
-     * [Instructions for submission](help/policies/instructions_for_submission.md)
      * [Paper ownership](help/authority.md)
      * [General submission policies](help/submit.md)
      * [Submission schedule and cutoff time](help/availability.md)

--- a/source/help/index.md
+++ b/source/help/index.md
@@ -32,7 +32,6 @@ slug: Help
 - [Submit an Article](submit.md)
 - [Submission schedule and cutoff time](availability.md)
 - [Submission terms and agreement](policies/submission_agreement.md)
-- [Instructions for submission](policies/instructions_for_submission.md)
 - [Replace an Article](replace.md)
 - [Withdraw an Article](withdraw.md)
 - [Add a Journal Reference, DOI or Report Number to an Article](jref.md)

--- a/source/help/license/index.md
+++ b/source/help/license/index.md
@@ -37,7 +37,7 @@ Ultimately, it is the submitter’s responsibility to choose the appropriate lic
 
 To make a license decision, arXiv recommends the following:
 
-1. Read and understand the [submission terms and agreement](../../help/policies/submission_agreement.md) and [instructions for submission](../../help/policies/instructions_for_submission.md)
+1. Read and understand the [submission terms and agreement](../../help/policies/submission_agreement.md).
 2. Understand the meanings and implications of each license below
 3. Check the policies of funders and journals (contact journals directly or using a third-party service such as [Sherpa Romeo](https://v2.sherpa.ac.uk/romeo/about.html))
 4. Consult with colleagues in your field of study

--- a/source/help/policies/code_of_conduct.md
+++ b/source/help/policies/code_of_conduct.md
@@ -51,7 +51,6 @@ Policies related to authors:
 - [Moderation](../../help/moderation/index.md) 
 - [Privacy](privacy_policy.md)
 - [Submission terms and agreement](submission_agreement.md)
-- [Instructions for submission](instructions_for_submission.md)
 - [Authorship policy](../../help/registerhelp.md)
 
 Policies related to moderators:

--- a/source/help/policies/index.md
+++ b/source/help/policies/index.md
@@ -11,7 +11,6 @@ Please note this page is a work in progress. We are working towards a comprehens
 ## Submission Policies
 - [General submission policies](../../help/submit.md)
 - [Submission terms and agreement](submission_agreement.md)
-- [Instructions for submission](instructions_for_submission.md)
 - [Submission schedule and cutoff time](../../help/availability.md)
 - [Moderation](../../help/moderation/index.md)
 - [License and copyright](../../help/license/index.md)

--- a/source/help/policies/submission_agreement.md
+++ b/source/help/policies/submission_agreement.md
@@ -4,54 +4,59 @@ arXiv is a curated research-sharing platform emphasizing openness, collaboration
 
 ## Representations and Warranties 
 
-I make the following representations and warranties: 
+​​​I make the following representations and warranties: 
 
-- I am the original author of the Work or a proxy pre-approved by arXiv administrators acting on behalf of an original author. 
-- If the Work was created by multiple authors, all of them have consented to the submission of the Work to arXiv. If I am signing and accepting the terms on behalf of another individual, I have been granted the authority to make the submittal by that individual, and my acceptance of the terms binds the other individual. 
+- I am the original author of the Work, or a proxy pre-approved by arXiv administrators acting on behalf of an original author. 
+- I am completing this agreement on behalf of and binding upon all author(s).  
+- I have full authority to enter into and make this Agreement and to grant the rights contained in this Agreement. If the Work was created by multiple authors, I affirm that my co-author(s) have consented to the submission of the Work to arXiv under the Agreement terms with me acting on my co-author(s)’ behalf.  
 - I have the right to include any third-party materials used in the Work. 
 - The use of any third-party materials is consistent with scholarly and academic standards of proper citation and acknowledgement of sources. 
-- The Work is not subject to any agreement, license, or other claim that could interfere with the rights granted to arXiv herein. 
-- The distribution of the Work by arXiv will not violate any rights of any person or entity, including, without limitation, any rights of copyright, patent, trade secret, privacy, or any other rights, and it contains no defamatory, obscene, or other unlawful matter. 
+- The Work is not subject to any agreement, license or other claim that could interfere with the rights granted to arXiv herein. 
+- The distribution of the Work by arXiv will not violate any rights of any person or entity, including without limitation any rights of copyright, patent, trade secret, privacy, or any other rights, and it contains no defamatory, obscene, or other unlawful matter. 
 - I will not enter into other agreements or make other commitments that would conflict with the rights granted to arXiv. 
 - I have the authority to make the statements, grant the rights, and take the actions described above. 
 
 ## Compliance with arXiv Policies 
 
-I agree to comply with all arXiv policies, including, but not limited to, those related to the [code of conduct](/help/policies/code_of_conduct.html), [moderation](/help/moderation/index.html), and [privacy](/help/policies/privacy_policy.html). My failure to so comply may result in arXiv suspending access, removing Works, or otherwise taking action it determines is necessary. I understand and agree that arXiv reserves the right, in its sole discretion, to take any action that arXiv determines is required in order to comply with applicable arXiv policies and any applicable laws, including but not limited to removal of a Work or blocking access to it.
+I agree to comply with all arXiv policies, including but not limited to, those related to the [code of conduct](/help/policies/code_of_conduct.html), [moderation](/help/moderation/index.html), and [privacy](/help/policies/privacy_policy.html). My failure to so comply may result in arXiv suspending access, removing Works, or otherwise taking action it determines is necessary. I understand and agree that arXiv reserves the right, in its sole discretion, to take any action that arXiv determines is required in order to comply with applicable arXiv policies and any applicable laws, including but not limited to removal of a Work or blocking access to it.  
 
 ## Curation of Content
 
-arXiv is a moderated repository for scholarly material, and, as such, maintains a permanent collection of submitted Works. arXiv maintains a record of all versions of Works that are submitted, including previous versions that have been updated and/or corrected. By making this submission to arXiv, I agree to the following:
+arXiv is a moderated repository for scholarly material, and, as such, maintains a permanent collection of submitted Works. arXiv maintains a record of all versions of Works that are submitted, including previous versions that have been updated and/or corrected. By making this submission to arXiv, I agree to the following: 
 
-- arXiv reserves the right to reclassify, reject, or remove any submission. 
-- Submissions will be automatically compared with other arXiv articles and detected text overlap may be noted.
-- In cases where public papers are found to violate arXiv policy, arXiv may withdraw the paper and indicate the concern in the Comments metadata.
-- Metadata may be corrected to conform to arXiv standards.
-
+- arXiv reserves the right to reclassify, reject, or remove any submission.  
+- Submissions will be automatically compared with other arXiv articles and detected text ​​​​overlap may be noted. 
+- In cases where public papers are found to violate arXiv policy that we may withdraw the paper and indicate the concern in the Comments metadata. 
+- Metadata may be corrected to conform to arXiv standards​​​​. 
+  
 ## Grant of the License to arXiv
 
 By making this submission to arXiv:
 
-- I grant arXiv a non-exclusive, perpetual, irrevocable, and royalty-free license to include the Work in the arXiv repository. 
-- I permit users to access, view, and make other uses of the work in a manner consistent with the services and objectives of arXiv. 
-- I agree that this license includes without limitation the right for arXiv to reproduce (e.g., upload, backup, archive, preserve, and allow online access), distribute (e.g., allow access), make available, and prepare versions of the Work (e.g., abstracts, and metadata or text files, formats to support accessibility, machine-readable formats) in analog, digital, or other formats existing now or in the future as arXiv may deem appropriate. 
-- I agree that the rights and licenses granted will move with arXiv if another educational institution assumes responsibility for arXiv. 
+- I grant arXiv a non-exclusive, perpetual, irrevocable, and royalty-free license to include the Work in the arXiv repository.  
+- I permit users to access, view, and make other uses of the work in a manner consistent with the services and objectives of arXiv.  
+- ​​​​​I agree that this license includes without limitation the right for arXiv to reproduce (e.g., upload, backup, archive, preserve, and allow online access), distribute (e.g., allow access), make available, and prepare versions of the Work (e.g., abstracts, and metadata or text files, formats to support accessibility, machine-readable formats) in analog, digital, or other formats existing now or in the future as arXiv may deem appropriate.  
+- I agree that the rights and licenses granted may be assigned, transferred, or otherwise conveyed to another organization that is assuming (taking over) any arXiv responsibilities.  
 
 ## Waiver of Rights and Indemnification
 
-I waive the following claims on behalf of myself and all other authors of the Work: 
+I waive the following claims on behalf of myself and all other authors of the Work with me acting on my co-author(s)’ behalf: 
 
-- Any claims against arXiv or Cornell University, or any officer, employee, or agent thereof, based upon the use of the Work by arXiv consistent with the License. 
-- Any claims against arXiv or Cornell University, or any officer, employee, or agent thereof, based upon actions taken by any such party with respect to the Work, including without limitation decisions to include the Work in, or exclude the Work from, the repository; editorial decisions or changes affecting the Work, including the identification of Submitters and their affiliations or titles; the classification or characterization of the Work; the content of any metadata; the availability or lack of availability of the Work to researchers or other users of arXiv, including any decision to include the Work initially or remove or disable access. 
+- Any claims against arXiv or Cornell University, or any officer, employee, or agent and their successors, assignees, or heirs (hereinafter “the indemnified parties”) thereof, based upon the use of the Work by arXiv consistent with the License. 
+- Any claims against the indemnified parties based upon actions taken by any such party with respect to the Work, including without limitation decisions to include the Work in, or exclude the Work from, the repository; editorial decisions or changes affecting the Work, including the identification of myself and contributing co-author(s) and our affiliations or titles; the classification or characterization of the Work; the content of any metadata; the availability or lack of availability of the Work to researchers or other users of arXiv, including any decision to include the Work initially or remove or disable access. 
 - Any rights related to the integrity of the Work under ​​​​moral rights principles. 
-- Any claims against arXiv or Cornell University, or any officer, employee, or agent thereof based upon any technical failures that result in a loss of content or inadvertent disclosure of information provided in connection with a submission.  
-- I will indemnify, defend, and hold harmless arXiv, Cornell University and its officers, employees, agents, and other affiliated parties from any loss, damage, or claim arising out of or related to: (a) any breach of any representations or warranties herein; (b) any failure by Submitter to perform any of Submitter’s obligations herein; and (c) any use of the Work as anticipated in the license and terms of submittal. 
+- Any claims against the indemnified parties based upon any technical failures that result in a loss of content or inadvertent disclosure of information provided in connection with a submission.  
+- I will indemnify, defend, and hold harmless the indemnified parties from any loss, damage, or claim arising out of or related to: (a) any breach of any representations or warranties herein; (b) any failure by myself or my co-author(s) to perform any of our obligations herein with me acting on my co-author(s)’ behalf; and (c) any use of the Work as anticipated in the License and terms of submittal. 
 
 ## Management of Copyright
 
-This grant to arXiv is a non-exclusive license and is not a grant of exclusive rights or a transfer of the copyright. Authors who either (a) retain their copyright in the Work; or (b) no longer retain their copyright before submission but do have the right to submit the Work, may enter into publication agreements or other arrangements regarding the Work, provided that such agreements or arrangements do not conflict with the ability of arXiv to exercise the rights and licenses granted to arXiv under this Agreement. arXiv has no obligation to protect or enforce any copyright in the Work, and arXiv has no obligation to respond to any permission requests or other inquiries regarding the copyright in or other uses of the Work. 
+This grant to arXiv is a non-exclusive license and is not a grant of exclusive rights or a transfer of the copyright. 
 
-You may elect to make the Work available under one of the following licenses that you shall select at the time of submission: 
+- I acknowledge that I may enter into publication agreements or other arrangements regarding the Work if I either (a) retain a copyright in the Work; or (b) no longer retain a copyright in the Work before submission but do have the right to submit the Work. 
+- I agree that it is my sole responsibility to ensure that any additional publication agreements or other arrangements do not prohibit or impair arXiv’s redistribution license or conflict with arXiv’s ability to exercise the rights and licenses granted under this Agreement.   
+- arXiv has no obligation to protect or enforce any copyright in the Work, and arXiv has no obligation to respond to any permission requests or other inquiries regarding the copyright in or other uses of the Work. 
+
+You may elect to make the Work available under one of the following ​​​​licenses that you shall select at the time of submission:  
 
 -  Creative Commons Attribution license (CC BY 4.0) (https://creativecommons.org/licenses/by/4.0/); 
 -  Creative Commons Attribution-ShareAlike license (CC BY-SA 4.0) (https://creativecommons.org/licenses/by-sa/4.0/); 
@@ -60,19 +65,19 @@ You may elect to make the Work available under one of the following licenses tha
 -  arXiv license (https://arxiv.org/licenses/nonexclusive-distrib/1.0/license.html); or 
 -  Creative Commons Public Domain Dedication (CC0 1.0) (https://creativecommons.org/share-your-work/public-domain/cc0/).
     
-If you wish to use a different CC license, select arXiv’s non-exclusive license to distribute in the arXiv submission process and indicate the desired Creative Commons license in the actual article. 
+If you wish to use a different CC license, then select arXiv’s non-exclusive license to distribute in the arXiv submission process and indicate the desired Creative Commons license in the actual article.  
 
-The Creative Commons licenses are explained here: https://creativecommons.org/licenses/.
+The Creative Commons licenses are explained here: https://creativecommons.org/licenses/. 
 
-You should take care to submit a work to arXiv _only if you are certain_ that you will not later wish to publish it in a journal or other outlet that prohibits prior distribution on an e-print server. _arXiv will not remove an announced article in order to comply with such a journal policy — the license granted upon submission is irrevocable._ 
+You should take care to submit a work to arXiv _only if you are certain_ that you will not later wish to publish it in a journal or other outlet that prohibits prior distribution on an e-print server. _arXiv will not remove an announced article in order to comply with such a journal policy – the license granted upon submission is irrevocable._ 
 
 ## Metadata license
 
-To the extent that you or arXiv has a copyright interest in metadata accompanying the submission, a Creative Commons CC0 1.0 Universal Public Domain Dedication will apply. Metadata includes title, author, abstract, and other information describing the Work.
+To the extent that you or arXiv has a copyright interest in metadata accompanying the submission, a Creative Commons CC0 1.0 Universal Public Domain Dedication will apply. Metadata includes title, author, abstract, and other information describing the Work. 
 
 ## General Provisions
 
-This Agreement will be governed by and construed in accordance with the substantive and procedural laws of the State of New York and the applicable federal law of the United States without reference to any conflicts of laws principles. 
+This Agreement will be governed by and construed in accordance with the substantive and procedural laws of the State of New York and the applicable federal law of the United States without reference to any conflicts of laws principles.  
 
 - By making this submission, I agree that any action, suit, arbitration, or other proceeding arising out of or related to this Agreement must be commenced in the state or federal courts serving Tompkins County, New York. 
-- I hereby consent on behalf of myself and any other authors to the personal jurisdiction of such courts. 
+- I, and on behalf of any and all authors, hereby consent to the personal jurisdiction of such courts. 

--- a/source/help/policies/submission_agreement.md
+++ b/source/help/policies/submission_agreement.md
@@ -7,12 +7,13 @@ arXiv is a curated research-sharing platform emphasizing openness, collaboration
 ​​​I make the following representations and warranties: 
 
 - I am the original author of the Work or a proxy pre-approved by arXiv administrators acting on behalf of an original author. 
-- I am completing this agreement on behalf of and binding upon all author(s).  
+- I am completing this Agreement on behalf of and binding upon all author(s).  
 - I have full authority to enter into and make this Agreement and to grant the rights contained in this Agreement. If the Work was created by multiple authors, I affirm that my co-author(s) have consented to the submission of the Work to arXiv under the Agreement terms with me acting on my co-author(s)’ behalf.  
 - I have the right to include any third-party materials used in the Work. 
 - The use of any third-party materials is consistent with scholarly and academic standards of proper citation and acknowledgement of sources. 
-- The Work is not subject to any agreement, license or other claim that could interfere with the rights granted to arXiv herein. 
-- The distribution of the Work by arXiv will not violate any rights of any person or entity, including, without limitation, any rights of copyright, patent, trade secret, privacy, or any other rights, and it contains no defamatory, obscene, or other unlawful matter. 
+- The Work is not subject to any agreement, license, or other claim that could interfere with the rights granted to arXiv herein. 
+- The distribution of the Work by arXiv will not violate any rights of any person or entity, including, without limitation, any rights of copyright, patent, trade secret, privacy, or any other rights.
+- The work contains no defamatory, obscene, or other unlawful matter.
 - I will not enter into other agreements or make other commitments that would conflict with the rights granted to arXiv. 
 - I have the authority to make the statements, grant the rights, and take the actions described above. 
 

--- a/source/help/policies/submission_agreement.md
+++ b/source/help/policies/submission_agreement.md
@@ -6,18 +6,18 @@ arXiv is a curated research-sharing platform emphasizing openness, collaboration
 
 I make the following representations and warranties: 
 
-- I am the original author of the Work, or a proxy pre-approved by arXiv administrators acting on behalf of an original author. 
-- If the Work was created by multiple authors, that all of them have consented to the submission of the Work to arXiv. If I am signing and accepting the terms on behalf of another individual, I have been granted the authority to make the submittal by that individual and my acceptance of the terms binds the other individual. 
+- I am the original author of the Work or a proxy pre-approved by arXiv administrators acting on behalf of an original author. 
+- If the Work was created by multiple authors, all of them have consented to the submission of the Work to arXiv. If I am signing and accepting the terms on behalf of another individual, I have been granted the authority to make the submittal by that individual, and my acceptance of the terms binds the other individual. 
 - I have the right to include any third-party materials used in the Work. 
 - The use of any third-party materials is consistent with scholarly and academic standards of proper citation and acknowledgement of sources. 
-- The Work is not subject to any agreement, license or other claim that could interfere with the rights granted to arXiv herein. 
-- The distribution of the Work by arXiv will not violate any rights of any person or entity, including without limitation any rights of copyright, patent, trade secret, privacy, or any other rights, and it contains no defamatory, obscene, or other unlawful matter. 
+- The Work is not subject to any agreement, license, or other claim that could interfere with the rights granted to arXiv herein. 
+- The distribution of the Work by arXiv will not violate any rights of any person or entity, including, without limitation, any rights of copyright, patent, trade secret, privacy, or any other rights, and it contains no defamatory, obscene, or other unlawful matter. 
 - I will not enter into other agreements or make other commitments that would conflict with the rights granted to arXiv. 
 - I have the authority to make the statements, grant the rights, and take the actions described above. 
 
 ## Compliance with arXiv Policies 
 
-I agree to comply with all arXiv policies, including but not limited to, those related to the [code of conduct](/help/policies/code_of_conduct.html), [moderation](/help/moderation/index.html), and [privacy](/help/policies/privacy_policy.html). My failure to so comply may result in arXiv suspending access, removing Works, or otherwise taking action it determines is necessary. I understand and agree that arXiv reserves the right, in its sole discretion, to take any action that arXiv determines is required in order to comply with applicable arXiv policies and any applicable laws, including but not limited to removal of a Work or blocking access to it.
+I agree to comply with all arXiv policies, including, but not limited to, those related to the [code of conduct](/help/policies/code_of_conduct.html), [moderation](/help/moderation/index.html), and [privacy](/help/policies/privacy_policy.html). My failure to so comply may result in arXiv suspending access, removing Works, or otherwise taking action it determines is necessary. I understand and agree that arXiv reserves the right, in its sole discretion, to take any action that arXiv determines is required in order to comply with applicable arXiv policies and any applicable laws, including but not limited to removal of a Work or blocking access to it.
 
 ## Curation of Content
 
@@ -25,7 +25,7 @@ arXiv is a moderated repository for scholarly material, and, as such, maintains 
 
 - arXiv reserves the right to reclassify, reject, or remove any submission. 
 - Submissions will be automatically compared with other arXiv articles and detected text overlap may be noted.
-- In cases where public papers are found to violate arXiv policy that we may withdraw the paper and indicate the concern in the Comments metadata.
+- In cases where public papers are found to violate arXiv policy, arXiv may withdraw the paper and indicate the concern in the Comments metadata.
 - Metadata may be corrected to conform to arXiv standards.
 
 ## Grant of the License to arXiv
@@ -45,7 +45,7 @@ I waive the following claims on behalf of myself and all other authors of the Wo
 - Any claims against arXiv or Cornell University, or any officer, employee, or agent thereof, based upon actions taken by any such party with respect to the Work, including without limitation decisions to include the Work in, or exclude the Work from, the repository; editorial decisions or changes affecting the Work, including the identification of Submitters and their affiliations or titles; the classification or characterization of the Work; the content of any metadata; the availability or lack of availability of the Work to researchers or other users of arXiv, including any decision to include the Work initially or remove or disable access. 
 - Any rights related to the integrity of the Work under ​​​​moral rights principles. 
 - Any claims against arXiv or Cornell University, or any officer, employee, or agent thereof based upon any technical failures that result in a loss of content or inadvertent disclosure of information provided in connection with a submission.  
-- I will indemnify, defend, and hold harmless arXiv, Cornell University and its officers, employees, agents, and other affiliated parties from any loss, damage, or claim arising out of or related to: (a) any breach of any representations or warranties herein; (b) any failure by Submitter to perform any of Submitter’s obligations herein; and (c) any use of the Work as anticipated in the License and terms of submittal. 
+- I will indemnify, defend, and hold harmless arXiv, Cornell University and its officers, employees, agents, and other affiliated parties from any loss, damage, or claim arising out of or related to: (a) any breach of any representations or warranties herein; (b) any failure by Submitter to perform any of Submitter’s obligations herein; and (c) any use of the Work as anticipated in the license and terms of submittal. 
 
 ## Management of Copyright
 
@@ -60,11 +60,11 @@ You may elect to make the Work available under one of the following licenses tha
 -  arXiv license (https://arxiv.org/licenses/nonexclusive-distrib/1.0/license.html); or 
 -  Creative Commons Public Domain Dedication (CC0 1.0) (https://creativecommons.org/share-your-work/public-domain/cc0/).
     
-If you wish to use a different CC license, then select arXiv’s non-exclusive license to distribute in the arXiv submission process and indicate the desired Creative Commons license in the actual article. 
+If you wish to use a different CC license, select arXiv’s non-exclusive license to distribute in the arXiv submission process and indicate the desired Creative Commons license in the actual article. 
 
 The Creative Commons licenses are explained here: https://creativecommons.org/licenses/.
 
-You should take care to submit a work to arXiv _only if you are certain_ that you will not later wish to publish it in a journal or other outlet that prohibits prior distribution on an e-print server. _arXiv will not remove an announced article in order to comply with such a journal policy – the license granted upon submission is irrevocable._ 
+You should take care to submit a work to arXiv _only if you are certain_ that you will not later wish to publish it in a journal or other outlet that prohibits prior distribution on an e-print server. _arXiv will not remove an announced article in order to comply with such a journal policy — the license granted upon submission is irrevocable._ 
 
 ## Metadata license
 

--- a/source/help/policies/submission_agreement.md
+++ b/source/help/policies/submission_agreement.md
@@ -6,13 +6,13 @@ arXiv is a curated research-sharing platform emphasizing openness, collaboration
 
 ​​​I make the following representations and warranties: 
 
-- I am the original author of the Work, or a proxy pre-approved by arXiv administrators acting on behalf of an original author. 
+- I am the original author of the Work or a proxy pre-approved by arXiv administrators acting on behalf of an original author. 
 - I am completing this agreement on behalf of and binding upon all author(s).  
 - I have full authority to enter into and make this Agreement and to grant the rights contained in this Agreement. If the Work was created by multiple authors, I affirm that my co-author(s) have consented to the submission of the Work to arXiv under the Agreement terms with me acting on my co-author(s)’ behalf.  
 - I have the right to include any third-party materials used in the Work. 
 - The use of any third-party materials is consistent with scholarly and academic standards of proper citation and acknowledgement of sources. 
 - The Work is not subject to any agreement, license or other claim that could interfere with the rights granted to arXiv herein. 
-- The distribution of the Work by arXiv will not violate any rights of any person or entity, including without limitation any rights of copyright, patent, trade secret, privacy, or any other rights, and it contains no defamatory, obscene, or other unlawful matter. 
+- The distribution of the Work by arXiv will not violate any rights of any person or entity, including, without limitation, any rights of copyright, patent, trade secret, privacy, or any other rights, and it contains no defamatory, obscene, or other unlawful matter. 
 - I will not enter into other agreements or make other commitments that would conflict with the rights granted to arXiv. 
 - I have the authority to make the statements, grant the rights, and take the actions described above. 
 
@@ -26,7 +26,7 @@ arXiv is a moderated repository for scholarly material, and, as such, maintains 
 
 - arXiv reserves the right to reclassify, reject, or remove any submission.  
 - Submissions will be automatically compared with other arXiv articles and detected text ​​​​overlap may be noted. 
-- In cases where public papers are found to violate arXiv policy that we may withdraw the paper and indicate the concern in the Comments metadata. 
+- In cases where public papers are found to violate arXiv policy, arXiv may withdraw the paper and indicate the concern in the Comments metadata. 
 - Metadata may be corrected to conform to arXiv standards​​​​. 
   
 ## Grant of the License to arXiv
@@ -65,7 +65,7 @@ You may elect to make the Work available under one of the following ​​​​
 -  arXiv license (https://arxiv.org/licenses/nonexclusive-distrib/1.0/license.html); or 
 -  Creative Commons Public Domain Dedication (CC0 1.0) (https://creativecommons.org/share-your-work/public-domain/cc0/).
     
-If you wish to use a different CC license, then select arXiv’s non-exclusive license to distribute in the arXiv submission process and indicate the desired Creative Commons license in the actual article.  
+If you wish to use a different CC license, select arXiv’s non-exclusive license to distribute in the arXiv submission process and indicate the desired Creative Commons license in the actual article.  
 
 The Creative Commons licenses are explained here: https://creativecommons.org/licenses/. 
 

--- a/source/help/policies/submission_agreement.md
+++ b/source/help/policies/submission_agreement.md
@@ -35,21 +35,21 @@ By making this submission to arXiv:
 - I grant arXiv a non-exclusive, perpetual, irrevocable, and royalty-free license to include the Work in the arXiv repository. 
 - I permit users to access, view, and make other uses of the work in a manner consistent with the services and objectives of arXiv. 
 - I agree that this license includes without limitation the right for arXiv to reproduce (e.g., upload, backup, archive, preserve, and allow online access), distribute (e.g., allow access), make available, and prepare versions of the Work (e.g., abstracts, and metadata or text files, formats to support accessibility, machine-readable formats) in analog, digital, or other formats existing now or in the future as arXiv may deem appropriate. 
-- I agree that the rights and licenses granted will move with arXiv if another educational institutioninstitutional assumes responsibility for arXiv. 
+- I agree that the rights and licenses granted will move with arXiv if another educational institutionin assumes responsibility for arXiv. 
 
 ## Waiver of Rights and Indemnification
 
-I waive the following claims on behalf of myself and all other authors of the Work:
+I waive the following claims on behalf of myself and all other authors of the Work: 
 
-- Any claims against arXiv or Cornell University, or any officer, employee, or agent thereof, based upon the use of the Work by arXiv consistent with the License.
-- Any claims against arXiv or Cornell University, or any officer, employee, or agent thereof, based upon actions taken by any such party with respect to the Work, including without limitation decisions to include the Work in, or exclude the Work from, the repository; editorial decisions or changes affecting the Work, including the identification of Submitters and their affiliations or titles; the classification or characterization of the Work; the content of any metadata; the availability or lack of availability of the Work to researchers or other users of arXiv, including any decision to include the Work initially or remove or disable access.
-- Any rights related to the integrity of the Work under moral rights principles.
-- Any claims against arXiv or Cornell University, or any officer, employee, or agent thereof based upon any technical failures that result in a loss of content or inadvertent disclosure of information provided in connection with a submission. 
-- I will indemnify, defend, and hold harmless arXiv, Cornell University and its officers, employees, agents, and other affiliated parties from any loss, damage, or claim arising out of or related to: (a) any breach of any representations or warranties herein; (b) any failure by Submitter to perform any of Submitter’s obligations herein; and (c) any use of the Work as anticipated in the License and terms of submittal.
+- Any claims against arXiv or Cornell University, or any officer, employee, or agent thereof, based upon the use of the Work by arXiv consistent with the License. 
+- Any claims against arXiv or Cornell University, or any officer, employee, or agent thereof, based upon actions taken by any such party with respect to the Work, including without limitation decisions to include the Work in, or exclude the Work from, the repository; editorial decisions or changes affecting the Work, including the identification of Submitters and their affiliations or titles; the classification or characterization of the Work; the content of any metadata; the availability or lack of availability of the Work to researchers or other users of arXiv, including any decision to include the Work initially or remove or disable access. 
+- Any rights related to the integrity of the Work under ​​​​moral rights principles. 
+- Any claims against arXiv or Cornell University, or any officer, employee, or agent thereof based upon any technical failures that result in a loss of content or inadvertent disclosure of information provided in connection with a submission.  
+- I will indemnify, defend, and hold harmless arXiv, Cornell University and its officers, employees, agents, and other affiliated parties from any loss, damage, or claim arising out of or related to: (a) any breach of any representations or warranties herein; (b) any failure by Submitter to perform any of Submitter’s obligations herein; and (c) any use of the Work as anticipated in the License and terms of submittal. 
 
 ## Management of Copyright
 
-This grant to arXiv is a non-exclusive license and is not a grant of exclusive rights or a transfer of the copyright. Authors who either (a) retain their copyright in the Work; or (b) no longer retain their copyright before submission but do have the right to submit the Work, may enter into publication agreements or other arrangements regarding the Work, provided that, such agreements or arrangements do not conflict with the ability of arXiv to exercise the rights and licenses granted to arXiv under this Agreement. arXiv has no obligation to protect or enforce any copyright in the Work, and arXiv has no obligation to respond to any permission requests or other inquiries regarding the copyright in or other uses of the Work.
+This grant to arXiv is a non-exclusive license and is not a grant of exclusive rights or a transfer of the copyright. Authors who either (a) retain their copyright in the Work; or (b) no longer retain their copyright before submission but do have the right to submit the Work, may enter into publication agreements or other arrangements regarding the Work, provided that such agreements or arrangements do not conflict with the ability of arXiv to exercise the rights and licenses granted to arXiv under this Agreement. arXiv has no obligation to protect or enforce any copyright in the Work, and arXiv has no obligation to respond to any permission requests or other inquiries regarding the copyright in or other uses of the Work. 
 
 You may elect to make the Work available under one of the following licenses that you shall select at the time of submission: 
 
@@ -60,11 +60,11 @@ You may elect to make the Work available under one of the following licenses tha
 -  arXiv license (https://arxiv.org/licenses/nonexclusive-distrib/1.0/license.html); or 
 -  Creative Commons Public Domain Dedication (CC0 1.0) (https://creativecommons.org/share-your-work/public-domain/cc0/).
     
-If you wish to use a different CC license, then select arXiv’s non-exclusive license to distribute in the arXiv submission process and indicate the desired Creative Commons license in the actual article.
+If you wish to use a different CC license, then select arXiv’s non-exclusive license to distribute in the arXiv submission process and indicate the desired Creative Commons license in the actual article. 
 
 The Creative Commons licenses are explained here: https://creativecommons.org/licenses/.
 
-You should take care to submit a work to arXiv only if you are certain that you will not later wish to publish it in a journal or other outlet that prohibits prior distribution on an e-print server. _arXiv will not remove an announced article in order to comply with such a journal policy – the license granted upon submission is irrevocable._
+You should take care to submit a work to arXiv _only if you are certain_ that you will not later wish to publish it in a journal or other outlet that prohibits prior distribution on an e-print server. _arXiv will not remove an announced article in order to comply with such a journal policy – the license granted upon submission is irrevocable._ 
 
 ## Metadata license
 
@@ -74,5 +74,5 @@ To the extent that you or arXiv has a copyright interest in metadata accompanyin
 
 This Agreement will be governed by and construed in accordance with the substantive and procedural laws of the State of New York and the applicable federal law of the United States without reference to any conflicts of laws principles. 
 
--  By making this submission, I agree that any action, suit, arbitration, or other proceeding arising out of or related to this Agreement must be commenced in the state or federal courts serving Tompkins County, New York.
--  I hereby consent on behalf of myself and any other authors to the personal jurisdiction of such courts.
+- By making this submission, I agree that any action, suit, arbitration, or other proceeding arising out of or related to this Agreement must be commenced in the state or federal courts serving Tompkins County, New York. 
+- I hereby consent on behalf of myself and any other authors to the personal jurisdiction of such courts. 

--- a/source/help/policies/submission_agreement.md
+++ b/source/help/policies/submission_agreement.md
@@ -1,56 +1,78 @@
 # arXiv Submittal Agreement Terms and Conditions
 
-Any person submitting a work for deposit in arXiv is required to assent to the following terms and conditions. The Submitter is an original author of the Work, or a proxy pre-approved by arXiv administrators acting on behalf of an original author. If the Submitter is signing and accepting the terms on behalf of another individual, the Submitter represents and warrants that the Submitter has been granted the authority to make the submittal by that individual and that the Submitter's acceptance of the terms binds that other individual.
+arXiv is a curated research-sharing platform emphasizing openness, collaboration, and scholarship. By submitting articles, comments, or other written work (the “Work”), you (including any other authors of the Work) are agreeing to comply with these terms, which is an agreement (the “Agreement”) between you and Cornell University on behalf of arXiv (“arXiv”).
 
 ## Representations and Warranties
 
-The Submitter makes the following representations and warranties:
+I make the following representations and warranties:
 
-- The Submitter is an original author of the Work, or a proxy pre-approved by arXiv administrators acting on behalf of an original author.  
-- If the Work was created by multiple authors, that all of them have consented to the submission of the Work to arXiv.
-- The Submitter has the right to include any third-party materials used in the Work.
-- The use of any third-party materials is consistent with scholarly and academic standards of proper citation  and acknowledgement of sources.
-- The Work is not subject to any agreement, license or other claim that could interfere with the rights granted herein.
+- I am the original author of the Work, or a proxy pre-approved by arXiv administrators acting on behalf of an original author.
+- If the Work was created by multiple authors, that all of them have consented to the submission of the Work to arXiv. If I am signing and accepting the terms on behalf of another individual, I have been granted the authority to make the submittal by that individual and my acceptance of the terms binds the other individual.
+- I have the right to include any third-party materials used in the Work.
+- The use of any third-party materials is consistent with scholarly and academic standards of proper citation and acknowledgement of sources.
+- The Work is not subject to any agreement, license or other claim that could interfere with the rights granted to arXiv herein.
 - The distribution of the Work by arXiv will not violate any rights of any person or entity, including without limitation any rights of copyright, patent, trade secret, privacy, or any other rights, and it contains no defamatory, obscene, or other unlawful matter.
-- The Submitter has authority to make the statements, grant the rights, and take the actions described above.
+- I will not enter into other agreements or make other commitments that would conflict with the rights granted to arXiv.
+ - I have the authority to make the statements, grant the rights, and take the actions described above.
+
+## Compliance with arXiv Policies
+
+I agree to comply with all arXiv policies, including but not limited to, those related to the [code of conduct](/help/policies/code_of_conduct.html), [moderation](/help/moderation/index.html), and [privacy](/help/policies/privacy_policy.html). My failure to so comply may result in arXiv suspending access, removing Works, or otherwise taking action it determines is necessary. I understand and agree that arXiv reserves the right, in its sole discretion, to take any action that arXiv determines is required in order to comply with applicable arXiv policies and any applicable laws, including but not limited to removal of a Work or blocking access to it.
+
+## Curation of Content
+
+arXiv is a moderated repository for scholarly material, and, as such, maintains a permanent collection of submitted Works. arXiv maintains a record of all versions of Works that are submitted, including previous versions that have been updated and/or corrected. By making this submission to arXiv, I agree to the following:
+
+- arXiv reserves the right to reclassify, reject, or remove any submission. 
+- Submissions will be automatically compared with other arXiv articles and detected text overlap may be noted.
+- In cases where public papers are found to violate arXiv policy that we may withdraw the paper and indicate the concern in the Comments metadata.
+- Metadata may be corrected to conform to arXiv standards.
 
 ## Grant of the License to arXiv
 
-The Submitter grants to arXiv upon submission of the Work a non-exclusive, perpetual, and royalty-free license to include the Work in the arXiv repository and permit users to access, view, and make other uses of the work in a manner consistent with the services and objectives of arXiv.  This License includes without limitation the right for arXiv to reproduce (e.g., upload, backup, archive, preserve, and allow online access), distribute (e.g., allow access), make available, and prepare versions of  the Work (e.g., , abstracts, and metadata or text files, formats to support accessibility, machine-readable formats) in analog, digital, or other formats as arXiv may deem appropriate. The rights granted will move with arXiv if arXiv moves to another steward.
+By making this submission to arXiv:
+
+- I grant arXiv a non-exclusive, perpetual, irrevocable, and royalty-free license to include the Work in the arXiv repository. 
+- I permit users to access, view, and make other uses of the work in a manner consistent with the services and objectives of arXiv. 
+- I agree that this license includes without limitation the right for arXiv to reproduce (e.g., upload, backup, archive, preserve, and allow online access), distribute (e.g., allow access), make available, and prepare versions of the Work (e.g., abstracts, and metadata or text files, formats to support accessibility, machine-readable formats) in analog, digital, or other formats existing now or in the future as arXiv may deem appropriate. 
+- I agree that the rights and licenses granted will move with arXiv if another educational institutioninstitutional assumes responsibility for arXiv. 
 
 ## Waiver of Rights and Indemnification
 
-The Submitter waives the following claims on behalf of themselves and all other authors:
+I waive the following claims on behalf of myself and all other authors of the Work:
 
 - Any claims against arXiv or Cornell University, or any officer, employee, or agent thereof, based upon the use of the Work by arXiv consistent with the License.
 - Any claims against arXiv or Cornell University, or any officer, employee, or agent thereof, based upon actions taken by any such party with respect to the Work, including without limitation decisions to include the Work in, or exclude the Work from, the repository; editorial decisions or changes affecting the Work, including the identification of Submitters and their affiliations or titles; the classification or characterization of the Work; the content of any metadata; the availability or lack of availability of the Work to researchers or other users of arXiv, including any decision to include the Work initially or remove or disable access.
-- Any rights related to the integrity of the Work under Moral Rights principles.
-- Any claims against arXiv or Cornell University, or any officer, employee, or agent thereof based upon any loss of content or disclosure of information provided in connection with a submission.
-- The Submitter will indemnify, defend, and hold harmless arXiv, Cornell University and its officers, employees, agents, and other affiliated parties from any loss, damage, or claim arising out of or related to: (a) any breach of any representations or warranties herein; (b) any failure by Submitter to perform any of Submitter’s obligations herein; and (c) any use of the Work as anticipated in the License and terms of submittal.
+- Any rights related to the integrity of the Work under moral rights principles.
+- Any claims against arXiv or Cornell University, or any officer, employee, or agent thereof based upon any technical failures that result in a loss of content or inadvertent disclosure of information provided in connection with a submission. 
+- I will indemnify, defend, and hold harmless arXiv, Cornell University and its officers, employees, agents, and other affiliated parties from any loss, damage, or claim arising out of or related to: (a) any breach of any representations or warranties herein; (b) any failure by Submitter to perform any of Submitter’s obligations herein; and (c) any use of the Work as anticipated in the License and terms of submittal.
 
 ## Management of Copyright
 
-This grant to arXiv is a non-exclusive license and is not a grant of exclusive rights or a transfer of the copyright.  The authors retain their copyright and may enter into publication agreements or other arrangements, so long as they do not conflict with the ability of arXiv to exercise its rights under the License.  arXiv has no obligation to protect or enforce any copyright in the Work, and arXiv has no obligation to respond to any permission requests or other inquiries regarding the copyright in or other uses of the Work.
+This grant to arXiv is a non-exclusive license and is not a grant of exclusive rights or a transfer of the copyright. Authors who either (a) retain their copyright in the Work; or (b) no longer retain their copyright before submission but do have the right to submit the Work, may enter into publication agreements or other arrangements regarding the Work, provided that, such agreements or arrangements do not conflict with the ability of arXiv to exercise the rights and licenses granted to arXiv under this Agreement. arXiv has no obligation to protect or enforce any copyright in the Work, and arXiv has no obligation to respond to any permission requests or other inquiries regarding the copyright in or other uses of the Work.
 
-The Submitter may elect to make the Work available under one of the following Creative Commons licenses that the Submitter shall select at the time of submission:
-Creative Commons Attribution license (CC BY 4.0);
-Creative Commons Attribution-ShareAlike license (CC BY-SA 4.0);
-Creative Commons Attribution-Noncommercial-ShareAlike license (CC BY-NC-SA 4.0);
-Creative Commons Attribution-NonCommercial-NoDerivatives license (CC BY-NC-ND 4.0);
-arXiv license (https://arxiv.org/licenses/nonexclusive-distrib/1.0/license.html); or
-Creative Commons Public Domain Dedication (CC0 1.0).
+You may elect to make the Work available under one of the following licenses that you shall select at the time of submission: 
 
-If you wish to use a different CC license, then select arXiv's non-exclusive license to distribute in the arXiv submission process and indicate the desired Creative Commons license in the actual article.
+-  Creative Commons Attribution license (CC BY 4.0) (https://creativecommons.org/licenses/by/4.0/); 
+-  Creative Commons Attribution-ShareAlike license (CC BY-SA 4.0) (https://creativecommons.org/licenses/by-sa/4.0/); 
+-  Creative Commons Attribution-Noncommercial-ShareAlike license (CC BY-NC-SA 4.0) (https://creativecommons.org/licenses/by-nc-sa/4.0/);
+-  Creative Commons Attribution-NonCommercial-NoDerivatives license (CC BY-NC-ND 4.0) (https://creativecommons.org/licenses/by-nc-nd/4.0/);
+-  arXiv license (https://arxiv.org/licenses/nonexclusive-distrib/1.0/license.html); or 
+-  Creative Commons Public Domain Dedication (CC0 1.0) (https://creativecommons.org/share-your-work/public-domain/cc0/).
+    
+If you wish to use a different CC license, then select arXiv’s non-exclusive license to distribute in the arXiv submission process and indicate the desired Creative Commons license in the actual article.
 
-The Creative Commons licenses are explained here:
-https://creativecommons.org/licenses/.
+The Creative Commons licenses are explained here: https://creativecommons.org/licenses/.
 
-### Metadata license
+You should take care to submit a work to arXiv only if you are certain that you will not later wish to publish it in a journal or other outlet that prohibits prior distribution on an e-print server. _arXiv will not remove an announced article in order to comply with such a journal policy – the license granted upon submission is irrevocable._
 
-To the extent that the Submitter or arXiv has a copyright interest in metadata accompanying the submission, a Creative Commons CC0 1.0 Universal Public Domain Dedication will apply. Metadata includes title, author, abstract, and other information describing the Work.
+## Metadata license
 
-
+To the extent that you or arXiv has a copyright interest in metadata accompanying the submission, a Creative Commons CC0 1.0 Universal Public Domain Dedication will apply. Metadata includes title, author, abstract, and other information describing the Work.
 
 ## General Provisions
 
-This Agreement will be governed by and construed in accordance with the substantive and procedural laws of the State of New York and the applicable federal law of the United States without reference to any conflicts of laws principles.  The Submitter agrees that any action, suit, arbitration, or other proceeding arising out of or related to this Agreement must be commenced in the state or federal courts serving Tompkins County, New York.  The Submitter hereby consents on behalf of the Submitter and any other authors to the personal jurisdiction of such courts.
+This Agreement will be governed by and construed in accordance with the substantive and procedural laws of the State of New York and the applicable federal law of the United States without reference to any conflicts of laws principles. 
+
+-  By making this submission, I agree that any action, suit, arbitration, or other proceeding arising out of or related to this Agreement must be commenced in the state or federal courts serving Tompkins County, New York.
+-  I hereby consent on behalf of myself and any other authors to the personal jurisdiction of such courts.

--- a/source/help/policies/submission_agreement.md
+++ b/source/help/policies/submission_agreement.md
@@ -1,21 +1,21 @@
-# arXiv Submittal Agreement Terms and Conditions
+# arXiv Submittal Agreement
 
-arXiv is a curated research-sharing platform emphasizing openness, collaboration, and scholarship. By submitting articles, comments, or other written work (the “Work”), you (including any other authors of the Work) are agreeing to comply with these terms, which is an agreement (the “Agreement”) between you and Cornell University on behalf of arXiv (“arXiv”).
+arXiv is a curated research-sharing platform emphasizing openness, collaboration, and scholarship. By submitting articles, comments, or other written work (the “Work”), you (including any other authors of the Work) are agreeing to comply with these terms, which is an agreement (the “Agreement”) between you and Cornell University on behalf of arXiv (“arXiv”). 
 
-## Representations and Warranties
+## Representations and Warranties 
 
-I make the following representations and warranties:
+I make the following representations and warranties: 
 
-- I am the original author of the Work, or a proxy pre-approved by arXiv administrators acting on behalf of an original author.
-- If the Work was created by multiple authors, that all of them have consented to the submission of the Work to arXiv. If I am signing and accepting the terms on behalf of another individual, I have been granted the authority to make the submittal by that individual and my acceptance of the terms binds the other individual.
-- I have the right to include any third-party materials used in the Work.
-- The use of any third-party materials is consistent with scholarly and academic standards of proper citation and acknowledgement of sources.
-- The Work is not subject to any agreement, license or other claim that could interfere with the rights granted to arXiv herein.
-- The distribution of the Work by arXiv will not violate any rights of any person or entity, including without limitation any rights of copyright, patent, trade secret, privacy, or any other rights, and it contains no defamatory, obscene, or other unlawful matter.
-- I will not enter into other agreements or make other commitments that would conflict with the rights granted to arXiv.
- - I have the authority to make the statements, grant the rights, and take the actions described above.
+- I am the original author of the Work, or a proxy pre-approved by arXiv administrators acting on behalf of an original author. 
+- If the Work was created by multiple authors, that all of them have consented to the submission of the Work to arXiv. If I am signing and accepting the terms on behalf of another individual, I have been granted the authority to make the submittal by that individual and my acceptance of the terms binds the other individual. 
+- I have the right to include any third-party materials used in the Work. 
+- The use of any third-party materials is consistent with scholarly and academic standards of proper citation and acknowledgement of sources. 
+- The Work is not subject to any agreement, license or other claim that could interfere with the rights granted to arXiv herein. 
+- The distribution of the Work by arXiv will not violate any rights of any person or entity, including without limitation any rights of copyright, patent, trade secret, privacy, or any other rights, and it contains no defamatory, obscene, or other unlawful matter. 
+- I will not enter into other agreements or make other commitments that would conflict with the rights granted to arXiv. 
+- I have the authority to make the statements, grant the rights, and take the actions described above. 
 
-## Compliance with arXiv Policies
+## Compliance with arXiv Policies 
 
 I agree to comply with all arXiv policies, including but not limited to, those related to the [code of conduct](/help/policies/code_of_conduct.html), [moderation](/help/moderation/index.html), and [privacy](/help/policies/privacy_policy.html). My failure to so comply may result in arXiv suspending access, removing Works, or otherwise taking action it determines is necessary. I understand and agree that arXiv reserves the right, in its sole discretion, to take any action that arXiv determines is required in order to comply with applicable arXiv policies and any applicable laws, including but not limited to removal of a Work or blocking access to it.
 

--- a/source/help/policies/submission_agreement.md
+++ b/source/help/policies/submission_agreement.md
@@ -35,7 +35,7 @@ By making this submission to arXiv:
 - I grant arXiv a non-exclusive, perpetual, irrevocable, and royalty-free license to include the Work in the arXiv repository. 
 - I permit users to access, view, and make other uses of the work in a manner consistent with the services and objectives of arXiv. 
 - I agree that this license includes without limitation the right for arXiv to reproduce (e.g., upload, backup, archive, preserve, and allow online access), distribute (e.g., allow access), make available, and prepare versions of the Work (e.g., abstracts, and metadata or text files, formats to support accessibility, machine-readable formats) in analog, digital, or other formats existing now or in the future as arXiv may deem appropriate. 
-- I agree that the rights and licenses granted will move with arXiv if another educational institutionin assumes responsibility for arXiv. 
+- I agree that the rights and licenses granted will move with arXiv if another educational institution assumes responsibility for arXiv. 
 
 ## Waiver of Rights and Indemnification
 

--- a/source/help/policies/submission_agreement.md
+++ b/source/help/policies/submission_agreement.md
@@ -19,7 +19,7 @@ arXiv is a curated research-sharing platform emphasizing openness, collaboration
 
 ## Compliance with arXiv Policies 
 
-I agree to comply with all arXiv policies, including but not limited to, those related to the [code of conduct](/help/policies/code_of_conduct.html), [moderation](/help/moderation/index.html), and [privacy](/help/policies/privacy_policy.html). My failure to so comply may result in arXiv suspending access, removing Works, or otherwise taking action it determines is necessary. I understand and agree that arXiv reserves the right, in its sole discretion, to take any action that arXiv determines is required in order to comply with applicable arXiv policies and any applicable laws, including but not limited to removal of a Work or blocking access to it.  
+I agree to comply with all arXiv policies, including but not limited to, those related to the [code of conduct](https://info.arxiv.org/help/policies/code_of_conduct.html), [moderation](https://info.arxiv.org/help/moderation/index.html), and [privacy](https://info.arxiv.org/help/policies/privacy_policy.html). My failure to so comply may result in arXiv suspending access, removing Works, or otherwise taking action it determines is necessary. I understand and agree that arXiv reserves the right, in its sole discretion, to take any action that arXiv determines is required in order to comply with applicable arXiv policies and any applicable laws, including but not limited to removal of a Work or blocking access to it.  
 
 ## Curation of Content
 

--- a/source/help/submit/index.md
+++ b/source/help/submit/index.md
@@ -9,7 +9,7 @@ Submissions to arXiv should be topical and refereeable scientific contributions 
 -   We only accept submissions from [registered authors](../registerhelp.md). If you are a new user or are submitting to a new category, you may be required to find [endorsements](../endorsement.md).
 -   All submissions are subject to a [moderation process](../moderation/index.md) that verifies material is appropriate and topical. Material that contains offensive language, non-scientific content, or is plagiarized may be removed.  
 -   Authors must grant arXiv.org an [irrevocable license to distribute](../license/index.md) the work.
--   Authors must agree to the [Submission Terms and Agreement](../policies/submission_agreement.md) and [Instructions for Submission](../policies/instructions_for_submission.md).
+-   Authors must agree to the [Submission Terms and Agreement](../policies/submission_agreement.md).
 -   Authors are expected to self-submit. Submissions by a third party are only accepted under limited conditions. See instructions for [third-party submissions](../third_party_submission.md) and [index submissions](../submit_index.md) for conference proceedings.
 -   New submissions received by 14:00 (Eastern Daylight/Standard Time Zone) are generally made available at 20:00 (Eastern) based on the [schedule for availability](../availability.md). Also see [versions help pages](../versions.md).
 


### PR DESCRIPTION
Minor change: I updated the help links in submission_agreement.md to resolve to info.arxiv.org.

The main changes to support the new submission agreement are coming soon in an arxiv-submit repository PR.