### PR TITLE
Updated link to supported packages to include file extension

### DIFF
--- a/source/help/submit_latex_best_practices.md
+++ b/source/help/submit_latex_best_practices.md
@@ -4,7 +4,7 @@ To help authors achieve well formatted HTML, and to avoid errors during conversi
 
 ## Use LaTeX Packages that will lead to good HTML 
 
-To improve conversion from LaTeX to HTML, use packages that are supported by the LaTeXML converter. [ [Please view the list of currently supported packages (ending in .ltxml).](https://corpora.mathweb.org/corpus/arxmliv/tex_to_html/info/loaded_file)
+To improve conversion from LaTeX to HTML, use packages that are supported by the LaTeXML converter. [Please view the list of currently supported packages (ending in .ltxml)](https://corpora.mathweb.org/corpus/arxmliv/tex_to_html/info/loaded_file).
 
 ### What if my publisher requires me to use a package that is not supported?
 

--- a/source/help/submit_latex_best_practices.md
+++ b/source/help/submit_latex_best_practices.md
@@ -4,7 +4,7 @@ To help authors achieve well formatted HTML, and to avoid errors during conversi
 
 ## Use LaTeX Packages that will lead to good HTML 
 
-To improve conversion from LaTeX to HTML, use packages that are supported by the LaTeXML converter. [Please view the list of currently supported packages.](https://corpora.mathweb.org/corpus/arxmliv/tex_to_html/info/loaded_file)
+To improve conversion from LaTeX to HTML, use packages that are supported by the LaTeXML converter. [ [Please view the list of currently supported packages (ending in .ltxml).](https://corpora.mathweb.org/corpus/arxmliv/tex_to_html/info/loaded_file)
 
 ### What if my publisher requires me to use a package that is not supported?
 


### PR DESCRIPTION
Then we also need to tweak the language on the [info.arxiv.org](http://info.arxiv.org/) page. Deyan had a good suggestion to minimally change that first link to:
“[Please view the list of currently supported packages (ending in .ltxml)](https://corpora.mathweb.org/corpus/arxmliv/tex_to_html/info/loaded_file)”