### PR TITLE
Document RSS feed changes

### DIFF
--- a/source/help/rss.md
+++ b/source/help/rss.md
@@ -21,11 +21,11 @@ Changes from the old RSS feed:
 
  - New base URL of rss.arxiv.org, instead of arxiv.org (arxiv.org/rss will redirect to rss.arxiv.org)
 
- - Status page at /feed/status
+ - Status page at [https://rss.arxiv.org/feed/status]()
 
  - New content updated at arXiv since midnight
 
- - Can request multiple categories with plus sign &mdash; for example, `hep-lat+math.C`
+ - Can request multiple categories with plus sign &ndash; for example, `https://rss.arxiv.org/rss/hep-lat+math.CV`
 
  - Limit of 2000 items
  

--- a/source/help/rss.md
+++ b/source/help/rss.md
@@ -19,19 +19,17 @@ arXiv RSS feeds.
 
 Changes from the old RSS feed:
 
- - new base URL of rss.arxiv.org, instead of just arxiv.org (arxiv.org/rss will redirect to rss.arxiv.org)
+ - New base URL of rss.arxiv.org, instead of arxiv.org (arxiv.org/rss will redirect to rss.arxiv.org)
 
- - status page at /feed/status
+ - Status page at /feed/status
 
- - new content updated at arxiv midnight
+ - New content updated at arXiv since midnight
 
- - categories are no longer case sensitive, cs.ai==cs.AI==CS.AI==CS.ai
+ - Can request multiple categories with plus sign &mdash; for example, `hep-lat+math.C`
 
- - can request multiple categories with + hep-lat+math.CO
-
- - limit of 2000 items
+ - Limit of 2000 items
  
- - categorization and order of new, cross, replace and replace-cross now matches listings
+ - Categorization and order of new, cross, replace and replace-cross now matches listings
 
  - An author list is now provided for each paper
 

--- a/source/help/rss.md
+++ b/source/help/rss.md
@@ -4,13 +4,13 @@ Daily updated RSS news feed pages are available for all active subject
 areas within arXiv. The URL for each category (whole archive or subject
 class) is constructed by appending the category name to
 `http://rss.arxiv.org/rss/`. For example, the URL for the RSS page for the
-Computer Science archive is `http://rss.arxiv.org/rss/cs`.
+Computer Science archive is [http://rss.arxiv.org/rss/cs]().
 
 News feeds are also available for individual subject classes of archives
 that have subject classes. A specific subject class is selected by
 appending a period (.) and the subject class letters to the URL. For
 example, the URL for the RSS page for Mathematics -- Quantum Algebra is
-`http://rss.arxiv.org/rss/math.QA`.
+[http://rss.arxiv.org/rss/math.QA]().
 
 Please review the [Terms of Use for arXiv APIs](api/tou.md) before using the
 arXiv RSS feeds.
@@ -33,7 +33,7 @@ Changes from the old RSS feed:
  
  - categorization and order of new, cross, replace and replace-cross now matches listings
 
-The RSS output complies with the [RSS 2.0 specification](https://www.rssboard.org/rss-specification). RSS 0.91, and 1.0 are no longer supported. Atom format is still supported -- for example `http://rss.arxiv.org/atom/math`.
+The RSS output complies with the [RSS 2.0 specification](https://www.rssboard.org/rss-specification). RSS 0.91, and 1.0 are no longer supported. Atom format is still supported -- for example [http://rss.arxiv.org/atom/math]().
 
 Looking for search results in an *RSS-like* format? See the [arXiv search
 API](api/index.md) for more information and usage instructions.

--- a/source/help/rss.md
+++ b/source/help/rss.md
@@ -33,6 +33,8 @@ Changes from the old RSS feed:
  
  - categorization and order of new, cross, replace and replace-cross now matches listings
 
+ - An author list is now provided for each paper
+
 The RSS output complies with the [RSS 2.0 specification](https://www.rssboard.org/rss-specification). RSS 0.91, and 1.0 are no longer supported. Atom format is still supported -- for example [http://rss.arxiv.org/atom/math]().
 
 Looking for search results in an *RSS-like* format? See the [arXiv search

--- a/source/help/rss.md
+++ b/source/help/rss.md
@@ -3,35 +3,37 @@
 Daily updated RSS news feed pages are available for all active subject
 areas within arXiv. The URL for each category (whole archive or subject
 class) is constructed by appending the category name to
-`http://arxiv.org/rss/`. For example, the URL for the RSS page for the
-Computer Science archive is `http://arxiv.org/rss/cs`.
+`http://rss.arxiv.org/rss/`. For example, the URL for the RSS page for the
+Computer Science archive is `http://rss.arxiv.org/rss/cs`.
 
 News feeds are also available for individual subject classes of archives
 that have subject classes. A specific subject class is selected by
 appending a period (.) and the subject class letters to the URL. For
 example, the URL for the RSS page for Mathematics -- Quantum Algebra is
-`http://arxiv.org/rss/math.QA`.
+`http://rss.arxiv.org/rss/math.QA`.
 
 Please review the [Terms of Use for arXiv APIs](api/tou.md) before using the
 arXiv RSS feeds.
 
-### Customization
+### January 2024 update
 
-By default arXiv links within the RSS pages are to the main site. You
-may optionally specify a parameter `mirror=fr`, where `fr` is the
-country code of the mirror links should point to (France, `fr.arxiv.org`
-in this case). The complete URL thus becomes
-`http://arxiv.org/rss/cs?mirror=fr`.
+Changes from the old RSS feed:
 
-By default the RSS output complies with the [RSS 1.0
-specification](http://web.resource.org/rss/1.0/). The optional `version`
-parameter may be used to specify alternate RSS versions. Versions
-[0.91](http://backend.userland.com/rss091),
-[1.0](http://web.resource.org/rss/1.0/), and
-[2.0](http://blogs.law.harvard.edu/tech/rss) are supported. This
-parameter may be combined with the `mirror` parameter. For example,
-`http://arxiv.org/rss/cs?mirror=fr&version=0.91` requests RSS version
-0.91 output with links to the French mirror.
+ - new base URL of rss.arxiv.org, instead of just arxiv.org (arxiv.org/rss will redirect to rss.arxiv.org)
+
+ - status page at /feed/status
+
+ - new content updated at arxiv midnight
+
+ - categories are no longer case sensitive, cs.ai==cs.AI==CS.AI==CS.ai
+
+ - can request multiple categories with + hep-lat+math.CO
+
+ - limit of 2000 items
+ 
+ - categorization and order of new, cross, replace and replace-cross now matches listings
+
+The RSS output complies with the [RSS 2.0 specification](https://www.rssboard.org/rss-specification). RSS 0.91, and 1.0 are no longer supported. Atom format is still supported -- for example `http://rss.arxiv.org/atom/math`.
 
 Looking for search results in an *RSS-like* format? See the [arXiv search
 API](api/index.md) for more information and usage instructions.


### PR DESCRIPTION
Note -- https://rss.arxiv.org is already live, but we haven't redirected http://arxiv.org/rss to it yet.

That should be accomplished by a blog post. But right now, this is kind of a 'soft' launch.