### PR TITLE
updated inaccurate content about use of download statistics

### DIFF
--- a/source/help/faq/statfaq.md
+++ b/source/help/faq/statfaq.md
@@ -10,5 +10,5 @@
     
   - ## Do you plan to use download statistics in any way?
 
-    Yes, we track and report the number of [downloads from arXiv](../../help/stats/index.md) and for our [institutional membership](../../about/membership.md), but we do not track by individual papers.
+    Yes, we track and report the number of [downloads from arXiv](../../help/stats/index.md), but we do not track by individual papers.
 


### PR DESCRIPTION
We do not track download statistics for our member institutions. I removed this information from our faq page. 