### PR TITLE
Fix broken link to submit/index.md from help page

### DIFF
--- a/source/help/index.md
+++ b/source/help/index.md
@@ -29,7 +29,7 @@ slug: Help
 - [Subscribe to E-Mail Listings](subscribe.md)
 
 ## Submission and Revision
-- [Submit an Article](submit.md)
+- [Submit an Article](submit/index.md)
 - [Submission schedule and cutoff time](availability.md)
 - [Submission terms and agreement](policies/submission_agreement.md)
 - [Replace an Article](replace.md)


### PR DESCRIPTION
Feel free to ditch/close/delete this PR and just copy this edit into your own commit.

This is a fix to a broken link on the live site as of 2024-02-27 16:00 UTC.