### PR TITLE
Corrected broken link on help moderation page

### DIFF
--- a/source/help/stat/index.md
+++ b/source/help/stat/index.md
@@ -1,5 +1,5 @@
 # Stat Disambiguation 
 
-[Click here](../statistics/index.md) for the help page for the statistics (stat) category for arXiv papers.
+[Click here](../statistics/index.md) to see information about the Statistics (stat) archive.
 
 [Click here](../stats/index.md) to see arXiv usage statistics.


### PR DESCRIPTION
The advisory committees page goes to a 404 at the following address: https://info.arxiv.org/about/people/scientific_ad_board.md.html#advisory_committees

It should go to: https://info.arxiv.org/about/people/editorial_advisory_council.html#section-editorial-committees