### PR TITLE
Fixing Submit Article Link on Help page

### DIFF
--- a/source/help/index.md
+++ b/source/help/index.md
@@ -29,7 +29,7 @@ slug: Help
 - [Subscribe to E-Mail Listings](subscribe.md)
 
 ## Submission and Revision
-- [Submit an Article](submit.md)
+- [Submit an Article](submit/index.md)
 - [Submission schedule and cutoff time](availability.md)
 - [Submission terms and agreement](policies/submission_agreement.md)
 - [Replace an Article](replace.md)


### PR DESCRIPTION
On the [arXiv Help Contents](https://info.arxiv.org/help/index.html) page, the [Submit an Article](https://info.arxiv.org/help/submit.md) link under "Submission and Revision" delivers a 404 since the URL is incorrect (https://info.arxiv.org/help/submit.md).

The link should go to: [General submission policies - arXiv info](https://info.arxiv.org/help/submit/)