### PR TITLE
Fixed broken link on Help page

### DIFF
--- a/source/about/people/volunteer_moderators.md
+++ b/source/about/people/volunteer_moderators.md
@@ -1,0 +1,30 @@
+# Volunteer Moderators
+
+(Content moderation)[/help/moderation/index.html] ensures that arXiv is a valuable resource for researchers. arXiv moderators check that submissions appear in relevant subject areas and are of likely interest to professional researchers. arXiv relies on hundreds of volunteers, who are subject matter experts, to achieve its mission.
+
+## What moderators do
+
+Moderators provide quick checks on submissions. If a submission looks acceptable, the moderator does nothing and the submission gets posted. The vast majority of submissions meet the requirements set by arXiv and can be posted quickly. Only if there are issues related to classification or the scholarly nature of the content does the moderator need to take action either to change the classification or indicate an issue.
+
+Moderators are not referees and are not doing detailed checks or providing feedback. A typical day may include screening 10 papers and may take about 10 minutes of time.
+
+## Benefits of moderation are:
+
+- Keeping up to date with the newest research in the field
+- Service to your colleagues in support of arXiv’s mission
+- Recognition for that service may count towards professional responsibilities
+- Community - our moderators, advisory board members, and staff are a collegial, engaged, and fun group
+- Involvement with evolving issues of scholarly norms and communications
+
+Moderation of arXiv is a team effort, with multiple moderators in each category working in tandem or trading schedules. This helps ensure that submissions are checked daily while allowing for personal flexibility. Working alongside moderators are the arXiv editorial staff that check submissions for technical requirements and provide support to moderators and authors. As arXiv continues to scale and adapt to community needs, our IT team is researching and developing new tools to supplement moderation.
+
+## Moderator expectations:
+
+- Check the submission list daily
+- Coordinate schedules with other moderators to ensure daily coverage of submissions
+- Follow arXiv’s evolving editorial code of practice
+- Provide feedback from the research community to your Section Editorial Committee
+
+## Current moderators
+
+All [arXiv moderators](https://arxiv.org/moderators) are approved by their [Section Editorial Committees](../../about/people/editorial_advisory_council.md#section-editorial-committees) and by arXiv staff.

--- a/source/help/index.md
+++ b/source/help/index.md
@@ -29,7 +29,7 @@ slug: Help
 - [Subscribe to E-Mail Listings](subscribe.md)
 
 ## Submission and Revision
-- [Submit an Article](submit.md)
+- [Submit an Article](submit/index.md)
 - [Submission schedule and cutoff time](availability.md)
 - [Submission terms and agreement](policies/submission_agreement.md)
 - [Replace an Article](replace.md)


### PR DESCRIPTION
On the [arXiv Help Contents](https://info.arxiv.org/help/index.html) page, the [Submit an Article](https://info.arxiv.org/help/submit.md) link under "Submission and Revision" delivers a 404 since the URL is incorrect (https://info.arxiv.org/help/submit.md).

The link should go to: [General submission policies - arXiv info](https://info.arxiv.org/help/submit/)