### PR TITLE
The license shown at the top of HTML papers should link to the license text

### DIFF
--- a/source/help/license/index.md
+++ b/source/help/license/index.md
@@ -45,23 +45,23 @@ To make a license decision, arXiv recommends the following:
 
 Licenses available
 ------------------
-> ![CC BY license icon](images/cc-by.png){.mkd-img-left} [CC BY](https://creativecommons.org/licenses/by/4.0/): Creative Commons Attribution  
+> ![CC BY license icon](images/cc-by.png){.mkd-img-left} [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/): Creative Commons Attribution  
 > This license allows reusers to distribute, remix, adapt, and build upon the material in any medium or format, so long as attribution is given to the creator. The license allows for commercial use.
 >
 > _Are you submitting a preprint and plan to publish this work in a journal? Many publishers allow preprints to be deposited with a CC BY license. Check directly with the journal to find out._
 #
-> ![CC BY-SA license icon](images/cc-by-sa.png){.mkd-img-left} [CC BY-SA](https://creativecommons.org/licenses/by-sa/4.0/): Creative Commons Attribution-ShareAlike  
+> ![CC BY-SA license icon](images/cc-by-sa.png){.mkd-img-left} [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/): Creative Commons Attribution-ShareAlike  
 > This license allows reusers to distribute, remix, adapt, and build upon the material in any medium or format, so long as attribution is given to the creator. The license allows for commercial use. If you remix, adapt, or build upon the material, you must license the modified material under identical terms.
 #
-> ![CC BY-NC-SA license icon](images/cc-by-nc-sa.png){.mkd-img-left} [CC BY-NC-SA](https://creativecommons.org/licenses/by-nc-sa/4.0/): Creative Commons Attribution-Noncommercial-ShareAlike  
+> ![CC BY-NC-SA license icon](images/cc-by-nc-sa.png){.mkd-img-left} [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/): Creative Commons Attribution-Noncommercial-ShareAlike  
 > This license allows reusers to distribute, remix, adapt, and build upon the material in any medium or format for noncommercial purposes only, and only so long as attribution is given to the creator. If you remix, adapt, or build upon the material, you must license the modified material under identical terms.
 #
-> ![CC BY-NC-ND license icon](images/cc-by-nc-nd.png){.mkd-img-left} [CC BY-NC-ND](https://creativecommons.org/licenses/by-nc-nd/4.0/): Creative Commons Attribution-Noncommercial-NoDerivatives  
+> ![CC BY-NC-ND license icon](images/cc-by-nc-nd.png){.mkd-img-left} [CC BY-NC-ND 4.0](https://creativecommons.org/licenses/by-nc-nd/4.0/): Creative Commons Attribution-Noncommercial-NoDerivatives  
 > This license allows reusers to copy and distribute the material in any medium or format in unadapted form only, for noncommercial purposes only, and only so long as attribution is given to the creator.
 >
 > _Many publishers allow “accepted manuscripts” to be deposited with a CC BY-NC-ND license, but there may be an embargo period. Check the journal’s policies to be certain._
 #
-> ![arXiv perpetual, non-exclusive license](images/arxiv-license.png){.mkd-img-left} [arXiv.org perpetual, non-exclusive license](https://arxiv.org/licenses/nonexclusive-distrib/1.0/)  
+> ![arXiv perpetual, non-exclusive license](images/arxiv-license.png){.mkd-img-left} [arXiv.org perpetual, non-exclusive license 1.0](https://arxiv.org/licenses/nonexclusive-distrib/1.0/)  
 > This license gives limited rights to arXiv to distribute the article, and also limits re-use of any type from other entities or individuals.
 >
 > _Some authors require a license that is not listed here. As long as the desired license does not restrict arXiv’s license, authors can select the arXiv license and then indicate the desired license in the first page of the article. This is a requirement of some funders and governments._

--- a/source/help/policies/content-types.md
+++ b/source/help/policies/content-types.md
@@ -84,9 +84,9 @@ arXiv encourages dialogue and debate about scientific matters. Normally this occ
 
 Requirements for Comments and Replies:
 
-- "Comments-on" content type must have a Title: "Comment(s) on '<title-of-original-paper>'" and the metadata Comments field must contain "comment(s) on <arXiv-ID>".
-- A response from the original authors is always permitted and must have a Title: "Reply to comment(s) on '<title-of-original-paper>'" and the Comments field must contain "reply to comment(s) on <arXiv-ID>" in the comment field.
-- In rare cases where the original paper is not on arXiv (see content rules) the arXiv-ID is replaced by a DOI.
+- "Comments-on" content type must have a Title: "Comment(s) on 'title-of-original-paper'" and the metadata Comments field must contain "comment(s) on arXiv-ID-of-the-original-paper".
+- A response from the original authors is always permitted and must have a Title: "Reply to comment(s) on 'title-of-original-paper'" and the Comments metadata field must contain "reply to comment(s) on arXiv-ID".
+- In rare cases where the original paper is not on arXiv (see content rules) the arXiv-ID is replaced by the external DOI.
 - A chain of continued responses and counterresponses is allowed only as new versions of the initial Comment and Reply; these will not be accepted as new papers with new arXiv-IDs. A given author or co-author may submit only one Comment on a particular paper. Any subsequent issues the author wishes to raise must be done through version updates of the original Comment.
 
   * A replacement can be used two ways to create a new version under the same arXiv-ID:


### PR DESCRIPTION
Added  version numbers to the licenses. So if we change license text in the future, any given paper should link to the license agreement as of when that paper was submitted.