### PR TITLE
arxivce-1221 Update Automated DOI & Journal Reference Updates from Journals

### DIFF
--- a/source/help/bib_feed.md
+++ b/source/help/bib_feed.md
@@ -1,13 +1,7 @@
 Automated DOI and journal reference updates from publishers
 ===========================================================
 
-arXiv collaborates with Inspire (formerly SPIRES) to automatically
-update arXiv metadata with the DOI and journal references of published
-versions. In 2006 this facility was extended to accept feeds of DOI and
-journal reference metadata associated with arXiv articles from
-publishers and other trusted parties. We believe that linkage between
-arXiv and publisher versions of articles is of benefit to both arXiv
-users and publishers. Prospective users should contact arXiv
+We believe that linkage between arXiv and publisher versions of articles is of benefit to both arXiv users and publishers. Prospective users should contact arXiv
 administrators to discuss possible use of this facility, *after* making 
 the XML feed available on their site for ingestion. 
 
@@ -20,14 +14,14 @@ article. The XML should use the following schema:
 
 -   <http://arxiv.org/schemas/doi_feed.xsd>
 
-and there are some example documents are at:
+Please view example documents at:
 
 -   <http://arxiv.org/schemas/doi_feed_test.xml>
 -   <http://arxiv.org/schemas/doi_feed_test2.xml>
 -   <http://arxiv.org/schemas/doi_feed_test3.xml>
 
 The body of the feed comprises `<article>` elements which must have a
-`preprint_id` attribute and either of both of the `doi` or `journal_ref`
+`preprint_id` attribute and either one or both  `doi` and `journal_ref`
 attributes:
 
 -   `preprint_id` - The identifier of the arXiv article that the `doi`
@@ -35,8 +29,8 @@ attributes:
     `arXiv:hep-th/9901001`).
 -   `doi` - One or more DOIs associated with the article. Multiple DOIs
     should be separated with spaces. There is no facility to qualify one
-    as the main article and another as an erratum or such hut it is
-    helpful is the main article DOI is first (e.g.
+    as the main article and another as an erratum or such but it is
+    helpful to list the main article DOI first (e.g.
     `10.1016/S0550-3213(01)00405-9`, see also [DOI metadata
     notes](prep.md#doi)).
 -   `journal_ref` - One or more full bibliographic references to a
@@ -47,8 +41,7 @@ attributes:
     also [journal reference metadata notes](prep.md#journal)).
 
 The XML format has a few historical oddities. The `identifier` attribute
-on the root element is used to check that we have the feed we expect and
-so should not change for a given publisher/source. The contents of the
+on the root element is used to check we have the feed we expect and should not change for a given publisher/source. The contents of the
 `<date>` element are not used during updates. It is useful for human
 debugging however, and should be set to the date the feed was generated.
 
@@ -56,17 +49,17 @@ Update protocol
 ---------------
 
 After establishing that an update source has reliable and correctly
-formatted metadata we usually arrange to poll a particular URL on a
+formatted metadata we arrange to poll a particular URL on a
 weekly or monthly schedule. Updates that appear in more than one polling
-are ignored. For very small feeds (up to 1000 entries say) it is
-reasonable to simply append to a growing list of updates. For most feeds
+are ignored. For very small feeds (up to 1000 entries) it is
+reasonable to simply append them to a growing list of updates. For most feeds
 only recent updates should be included. We recommend that two
 polling-periods worth of updates are included so that updates won't be
-missed if something goes awry with one polling cycle.
+missed if something goes wrong with one of the polling cycles.
 
-Problems, errors...
+Problems or errors
 -------------------
 
 Updates are automatic so it is vital that feeds contain reliable data.
-Details of errors or other problem should be communicated to arXiv
-administrators as soon as possible.
+Details of errors or other problems should be [communicated to arXiv
+administrators](https://info.arxiv.org/help/contact.html) as soon as possible. 

--- a/source/help/policies/content-types.md
+++ b/source/help/policies/content-types.md
@@ -86,7 +86,7 @@ Requirements for Comments and Replies:
 
 - "Comments-on" content type must have a Title: "Comment(s) on 'title-of-original-paper'" and the metadata Comments field must contain "comment(s) on arXiv-ID-of-the-original-paper".
 - A response from the original authors is always permitted and must have a Title: "Reply to comment(s) on 'title-of-original-paper'" and the Comments metadata field must contain "reply to comment(s) on arXiv-ID".
-- In rare cases where the original paper is not on arXiv (see content rules) the arXiv-ID is replaced by the external DOI.
+- In rare cases where the original paper is not on arXiv the arXiv-ID is replaced by the external DOI.
 - A chain of continued responses and counterresponses is allowed only as new versions of the initial Comment and Reply; these will not be accepted as new papers with new arXiv-IDs. A given author or co-author may submit only one Comment on a particular paper. Any subsequent issues the author wishes to raise must be done through version updates of the original Comment.
 
   * A replacement can be used two ways to create a new version under the same arXiv-ID:


### PR DESCRIPTION
Update [Automated DOI and journal reference updates from publishers - arXiv info](https://info.arxiv.org/help/bib_feed.html)  to remove outdated information about collaborations.