### PR TITLE
Added Vice Chair to Sumati Suruya listing

### DIFF
--- a/source/about/people/science_advisory_council.md
+++ b/source/about/people/science_advisory_council.md
@@ -34,7 +34,7 @@ Astrophysik, Germany
 
 **Ronitt Rubinfeld (2023-2026)**, Edwin S. Webster Professor of Electrical Engineering and Computer Science, Massachusetts Institute of Technology
 
-**Sumati Suruya (2023-2026)**, Professor of Theoretical Physics, Raman Research Institute
+**Sumati Suruya (Vice Chair, 2023-2026)**, Professor of Theoretical Physics, Raman Research Institute
 
 **Sara del Valle (2023-2026)**, Deputy Group Leader, Los Alamos National Laboratory
 


### PR DESCRIPTION
Sumati Surya has been confirmed as the vice chair of the Science Advisory Council. Updated SAC page to reflect this. [https://info.arxiv.org/about/people/science_advisory_council.html ](https://info.arxiv.org/about/people/science_advisory_council.html)

  Sumati's term as chair is the same as her term on the council.