### PR TITLE
arxivce-1606 created consistent links from archives to moderators page

### DIFF
--- a/source/help/cs/index.md
+++ b/source/help/cs/index.md
@@ -4,7 +4,7 @@ Welcome to the Computing Research Repository (CoRR) in arXiv. The Computer Scien
 
 You can view the subject category descriptions and browse papers from the [main CS archive page](https://arxiv.org/archive/cs). New readers and authors to arXiv should see our help pages for [registration](../registerhelp.md), [submission](../submit.md) and [subscription](../subscribe.md).
 
-The [moderators for cs are listed here](https://arxiv.org/moderators/#cs).
+The [moderators for the computer science archive are listed here](https://arxiv.org/moderators/#cs).
 
 ### Computer Science Section Editorial Committee
 

--- a/source/help/econ/index.md
+++ b/source/help/econ/index.md
@@ -4,7 +4,7 @@ The Economics archive formed 26 September 2017 and you can read about the [annou
 
 You can browse articles and view categories at the [main economics archive page](https://arxiv.org/archive/econ).
 
-The [moderators for economics are listed here](https://arxiv.org/moderators#economics#economics).
+The [moderators for the economics archive are listed here](https://arxiv.org/moderators#economics#economics).
 
 
 <span id="AdvisoryCommittee"></span>

--- a/source/help/eess/index.md
+++ b/source/help/eess/index.md
@@ -4,7 +4,7 @@ The Electrical Engineering and Systems Science (eess) archive formed 18 Septembe
 
 You can browse articles and view categories at the [main eess archive page](https://arxiv.org/archive/eess).
 
-The [moderators for are listed here](https://arxiv.org/moderators#eess).
+The [moderators for the electrical engineering and systems science archive listed here](https://arxiv.org/moderators#eess).
 
 <span id="AdvisoryCommittee"></span>
 ## The arXiv Electrical Engineering and Systems Editorial Committee

--- a/source/help/math/index.md
+++ b/source/help/math/index.md
@@ -4,7 +4,7 @@ The Math (math) archive formed on 1 December 1997 and you can read about the [an
 
 You can browse articles and view categories at the [main math archive page](https://arxiv.org/archive/math).
 
-The [moderators for math are listed here](https://arxiv.org/moderators#math#math).
+The [moderators for the math archive are listed here](https://arxiv.org/moderators#math#math).
 
 <span id="AdvisoryCommittee"></span>
 

--- a/source/help/physics/index.md
+++ b/source/help/physics/index.md
@@ -18,7 +18,7 @@ You can browse articles and view categories at the individual archive pages:
 - Physics [physics](https://arxiv.org/archive/physics)
 - Quantum Physics [quant-ph](https://arxiv.org/archive/quant-ph)
 
-The [moderators for physics are listed here](https://arxiv.org/moderators#physics#physics).
+The [moderators for the physics archive are listed here](https://arxiv.org/moderators#physics#physics).
 
 <span id="AdvisoryCommittee"></span>
 ## The arXiv Physics Section Editorial Committee:

--- a/source/help/q-bio/index.md
+++ b/source/help/q-bio/index.md
@@ -4,7 +4,7 @@ The Quantitative Biology (q-bio) archive formed on 15 Sep 2003 and you can read 
 
 You can browse articles and view categories at the [main quantitative biology archive page](https://arxiv.org/archive/q-bio).
 
-The [moderators for q-bio are listed here](https://arxiv.org/moderators#q-bio#q-bio).
+The [moderators for the quantitative biology archive are listed here](https://arxiv.org/moderators#q-bio#q-bio).
 
 <span id="AdvisoryCommittee"></span>
 

--- a/source/help/q-fin/index.md
+++ b/source/help/q-fin/index.md
@@ -7,7 +7,7 @@ explanation of the objectives, see the original q-fin announcement.
 
 You can browse articles and view categories at the [main quantitative finance archive page](https://arxiv.org/archive/q-fin).
 
-The [moderators are listed here](https://arxiv.org/moderators#q-fin).
+The [moderators for the quantitative finance archive are listed here](https://arxiv.org/moderators#q-fin).
 
 
 ## The arXiv Quantitative Finance Section Editorial Committee:

--- a/source/help/statistics/index.md
+++ b/source/help/statistics/index.md
@@ -4,7 +4,7 @@ The Statistics archive formed on 1 April 2007 and you can read about the [announ
 
 You can browse articles and view categories at the [main statistics archive page](https://arxiv.org/archive/stat).
 
-The [moderators for statistics are listed here](https://arxiv.org/moderators#statistics#statistics).
+The [moderators for the statistics archive are listed here](https://arxiv.org/moderators#statistics#statistics).
 
 <span id="AdvisoryCommittee"></span>
 ## The arXiv Statistics Editorial Committee:


### PR DESCRIPTION
Create consistent messaging for the links on each page. e.g. “The moderators for the computer science archive are listed here.”

[Computer Science archive - arXiv info](https://info.arxiv.org/help/cs/index.html) 
[Electrical Engineering and Systems Science archive - arXiv info](https://info.arxiv.org/help/eess/index.html) 
[Economics archive - arXiv info](https://info.arxiv.org/help/econ/index.html) 
[About the Physics Archive - arXiv info](https://info.arxiv.org/help/physics/index.html) 
[About the Math archive - arXiv info](https://info.arxiv.org/help/math/index.html) 
[About the Quantitative Biology archive - arXiv info](https://info.arxiv.org/help/q-bio/index.html) 
[About The Quantitative Finance archive - arXiv info](https://info.arxiv.org/help/q-fin/index.html) 
[About the Statistics Archive - arXiv info](https://info.arxiv.org/help/statistics/index.html)