### PR TITLE
Added javascript rejection verbiage to submit/ancillary file pages

### DIFF
--- a/source/help/ancillary_files.md
+++ b/source/help/ancillary_files.md
@@ -17,7 +17,15 @@ files might include:
 -   Workbooks and spreadsheets
 
 arXiv accepts ancillary material only in support of research articles
-submitted. Note that tex files should not be included in this directory. Additionally, no pointers inside your codebase should reference this directory (it will change upon announcement, and any linking may be lost). Full text placed in the ancillary directory will *not* be indexed in searches. For information on submitting supplemental text that can be indexed, please see [this tex help page](submit_tex.md#autoignore).
+submitted. Please take note of the following submission tips:
+ 
+- TeX files should not be included in the ancillary file directory. 
+- Pointers inside your codebase should not reference this directory (linking may be lost upon announcement). 
+- Full text placed in the ancillary directory will not be indexed in searches.
+- PDF files with embedded JavaScript will cause your submission to fail (embedded JavaScript is a security risk to arXiv’s systems).
+    - Remove or disable JavaScript when building your PDF or generate PDFs using standard tools such as Adobe Distiller.
+    - Submit all movies and animated GIFS as separate ancillary files. 
+
 
 Submission of ancillary files
 -----------------------------

--- a/source/help/ancillary_files.md
+++ b/source/help/ancillary_files.md
@@ -24,7 +24,7 @@ submitted. Please take note of the following submission tips:
 - Full text placed in the ancillary directory will not be indexed in searches.
 - PDF files with embedded JavaScript will cause your submission to fail (embedded JavaScript is a security risk to arXiv’s systems).
     - Remove or disable JavaScript when building your PDF or generate PDFs using standard tools such as Adobe Distiller.
-    - Submit all movies and animated GIFS as separate ancillary files. 
+    - Submit all movies and animated GIFS as separate (non-JavaScript) ancillary files. 
 
 
 Submission of ancillary files

--- a/source/help/submit_pdf.md
+++ b/source/help/submit_pdf.md
@@ -56,7 +56,7 @@ Avoid Embedded JavaScript
 -------------------------------------------------------
 Do not include embedded JavaScript such as animated gifs, movies, HTML in your PDF. Submissions with embedded JavaScript are automatically rejected due to the potential security risks posed to arXiv systems. 
 
-- Submit all movies and animated GIFS as separate ancillary files.
+- Submit all movies and animated GIFS as separate(non-JavaScript) ancillary files.
 - Remove or disable JavaScript when building your PDF or generate PDFs using standard tools such as Adobe Distiller or one of the free conversion utilities mentioned above. 
 
 <span id="fonts"></span>Fonts within PDF

--- a/source/help/submit_pdf.md
+++ b/source/help/submit_pdf.md
@@ -52,6 +52,13 @@ one of these free conversion utilities:
 (Please contact us if this information is out of date or if you can
 suggest other free tools that are better.)
 
+Avoid Embedded JavaScript
+-------------------------------------------------------
+Do not include embedded JavaScript such as animated gifs, movies, HTML in your PDF. Submissions with embedded JavaScript are automatically rejected due to the potential security risks posed to arXiv systems. 
+
+- Submit all movies and animated GIFS as separate ancillary files.
+- Remove or disable JavaScript when building your PDF or generate PDFs using standard tools such as Adobe Distiller or one of the free conversion utilities mentioned above. 
+
 <span id="fonts"></span>Fonts within PDF
 -------------------------------------------------------
 

--- a/source/help/submit_tex.md
+++ b/source/help/submit_tex.md
@@ -75,6 +75,13 @@ The most flexible and robust figure inclusion is provided by the `graphics` and 
 
 Note that some software will permit you to include a mix of PostScript and PDFLaTeX-compatible figures and will perform the conversions to the appropriate format for you on the fly. arXiv does not permit such software to run during the AutoTeX processing. Why? It is possible for conversion issues to arise that can alter the scientific meaning or interpretation of your figure. Rather than invite such possibilities, we require that you use a unified figure format.
 
+#### Avoid embedding JavaScript in your PDF files
+
+Do not include embedded JavaScript such as animated gifs, movies, HTML in your PDF. Submissions with embedded JavaScript are automatically rejected due to the potential security risks posed to arXiv systems. 
+- Submit all movies and animated GIFS as separate ancillary files. 
+- Remove or disable JavaScript when building your PDF or generate PDFs using standard tools such as Adobe Distiller. 
+
+
 #### Separate figures with LaTeX submissions
 
 Figures in **jpeg**, **png**, or **gif** format may be submitted alongside native (La)TeX submissions provided that they are **not** included in the source file.. PDF or other formats not listed above are not permitted with (La)TeX submission; use [PDFLaTeX](#pdflatex) instead for PDF, jpeg, or png figures.

--- a/source/help/submit_tex.md
+++ b/source/help/submit_tex.md
@@ -78,7 +78,7 @@ Note that some software will permit you to include a mix of PostScript and PDFLa
 #### Avoid embedding JavaScript in your PDF files
 
 Do not include embedded JavaScript such as animated gifs, movies, HTML in your PDF. Submissions with embedded JavaScript are automatically rejected due to the potential security risks posed to arXiv systems. 
-- Submit all movies and animated GIFS as separate ancillary files. 
+- Submit all movies and animated GIFS as separate(non-JavaScript) ancillary files. 
 - Remove or disable JavaScript when building your PDF or generate PDFs using standard tools such as Adobe Distiller. 
 
 


### PR DESCRIPTION
Compose/Add "Rejecting Files with Javascript" Language to [info.arxiv.org](http://info.arxiv.org/) docs on the following pages: 

[Ancillary Files (data, code, images) - arXiv info](https://info.arxiv.org/help/ancillary_files.html)

 [Submit TeX/LaTeX - arXiv info](https://info.arxiv.org/help/submit_tex.html#latex) 

[Pdf - arXiv info](https://info.arxiv.org/help/pdf.html)