### PR TITLE
Fix docs for 4 digit year

### DIFF
--- a/source/help/arxiv_identifier_for_services.md
+++ b/source/help/arxiv_identifier_for_services.md
@@ -144,16 +144,16 @@ The URL patterns for all standard arXiv functions are consistent for the
 different forms of the arXiv identifier. Some examples are given in the
 table below:
 
-|                              | Generic               | Example with old id (9107-0703) | Example with new id (0704-1412) | Example new id (1501-)    |
-|------------------------------|-----------------------|---------------------------------|---------------------------------|---------------------------|
-| Abstract (normal HTML)       | `/abs/id`             | `/abs/hep-th/9901001`           | `/abs/0706.0001`                | `/abs/1501.00001`         |
-| Abstract (raw txt)           | `/abs/id?fmt=txt`     | `/abs/hep-th/9901001?fmt=txt`   | `/abs/0706.0001?fmt=txt`        | `/abs/1501.00001?fmt=txt` |
-| PDF                          | `/pdf/id.pdf`         | `/pdf/hep-th/9901001.pdf`       | `/pdf/0706.0001.pdf`            | `/pdf/1501.00001.pdf`     |
-| PS                           | `/ps/id`              | `/ps/hep-th/9901001`            | `/ps/0706.0001`                 | `/ps/1501.00001`          |
-| Source (.gz,.tar.gz,.pdf...) | `/src/id`             | `/src/hep-th/9901001`           | `/src/0706.0001`                | `/src/1501.00001`         |
-| Trackbacks                   | `/tb/id`              | `/tb/hep-th/9901001`            | `/tb/0706.0001`                 | `/tb/1501.00001`          |
-| New listings                 | `/list/arch-ive/new`  | `/list/hep-th/new`              | `/list/hep-th/new`              | `/list/hep-th/new`        |
-| Month listings               | `/list/arch-ive/yymm` | `/list/hep-th/0601`             | `/list/hep-th/0601`             | `/list/hep-th/0601`       |
+|                              | Generic                 | Example with old id (9107-0703) | Example with new id (0704-1412) | Example new id (1501-)    |
+|------------------------------|-------------------------|---------------------------------|---------------------------------|---------------------------|
+| Abstract (normal HTML)       | `/abs/id`               | `/abs/hep-th/9901001`           | `/abs/0706.0001`                | `/abs/1501.00001`         |
+| Abstract (raw txt)           | `/abs/id?fmt=txt`       | `/abs/hep-th/9901001?fmt=txt`   | `/abs/0706.0001?fmt=txt`        | `/abs/1501.00001?fmt=txt` |
+| PDF                          | `/pdf/id.pdf`           | `/pdf/hep-th/9901001.pdf`       | `/pdf/0706.0001.pdf`            | `/pdf/1501.00001.pdf`     |
+| PS                           | `/ps/id`                | `/ps/hep-th/9901001`            | `/ps/0706.0001`                 | `/ps/1501.00001`          |
+| Source (.gz,.tar.gz,.pdf...) | `/src/id`               | `/src/hep-th/9901001`           | `/src/0706.0001`                | `/src/1501.00001`         |
+| Trackbacks                   | `/tb/id`                | `/tb/hep-th/9901001`            | `/tb/0706.0001`                 | `/tb/1501.00001`          |
+| New listings                 | `/list/arch-ive/new`    | `/list/hep-th/new`              | `/list/hep-th/new`              | `/list/hep-th/new`        |
+| Month listings               | `/list/arch-ive/yyyy-mm`| `/list/hep-th/2006-01`          | `/list/hep-th/2006-01`          | `/list/hep-th/2006-01`    |
 
 Anyone using `/ftp/...` URLs should take the opportunity to change to
 the URLs given above since we plan to disable all access to `/ftp/...`

--- a/source/new/condreorg.md
+++ b/source/new/condreorg.md
@@ -1,6 +1,6 @@
 # Cond-mat archive reorganization
 
-Because of the continued growth of the cond-mat e-print archive (see the [monthly totals](http://xxx.lanl.gov/year/cond-mat/96)), many people have desired a bit of reorganization. This is now implemented.
+Because of the continued growth of the cond-mat e-print archive (see the [monthly totals](http://xxx.lanl.gov/year/cond-mat/1996)), many people have desired a bit of reorganization. This is now implemented.
 
 Now on cond-mat you can include a **Subj-class:** header with submissions. This is most easily done with a select menu for [web submissions](/uploads), or alternatively it can be included in e-mail submissions; see our [abstract preparation help](../help/prep.md). Subject classes must be chosen from the list below. People who subscribe to cond-mat as is would see no difference, except the listings can be sorted by the subject classification. You may, however, subscribe to any subset of classifications; see our [physics subscription help](http://xxx.lanl.gov/new/physsub.html). In this sense, each subject class is like a new archive.
 


### PR DESCRIPTION
update docs to reflect changes with /list and /year using 4 digit years for their urls