### PR TITLE
Update "Comments and Replies to Comments" metadata requirements

### DIFF
--- a/source/help/policies/content-types.md
+++ b/source/help/policies/content-types.md
@@ -84,9 +84,9 @@ arXiv encourages dialogue and debate about scientific matters. Normally this occ
 
 Requirements for Comments and Replies:
 
-- "Comments-on" content type must have a Title: "Comment(s) on 'title-of-original-paper'" and the metadata Comments field must contain "comment(s) on arXiv-ID-of-the-original-paper".
-- A response from the original authors is always permitted and must have a Title: "Reply to comment(s) on 'title-of-original-paper'" and the Comments metadata field must contain "reply to comment(s) on arXiv-ID".
-- In rare cases where the original paper is not on arXiv the arXiv-ID is replaced by the external DOI.
+- “Comments-on” papers must include the arXiv-ID of the original paper in the Title and/or Comments metadata fields (e.g., “comment(s) on arXiv:YYMM.NNNNN").
+- When a “comments-on” paper is published on arXiv, a reply from the authors of the original paper is always permitted (subject to the same moderation criteria as comments). Reply submissions should include the arXiv-ID of the “comments-on” paper to which they respond in the Title and/or Comments metadata fields (e.g., “reply to arXiv: YYMM.NNNNN”).
+- In rare cases where the original paper is not on arXiv, the DOI of the original paper should be used to identify it in the metadata in place of an arXiv-ID.
 - A chain of continued responses and counterresponses is allowed only as new versions of the initial Comment and Reply; these will not be accepted as new papers with new arXiv-IDs. A given author or co-author may submit only one Comment on a particular paper. Any subsequent issues the author wishes to raise must be done through version updates of the original Comment.
 
   * A replacement can be used two ways to create a new version under the same arXiv-ID:

--- a/source/help/policies/content-types.md
+++ b/source/help/policies/content-types.md
@@ -85,7 +85,7 @@ arXiv encourages dialogue and debate about scientific matters. Normally this occ
 Requirements for Comments and Replies:
 
 - “Comments-on” papers must include the arXiv-ID of the original paper in the Title and/or Comments metadata fields (e.g., “comment(s) on arXiv:YYMM.NNNNN").
-- When a “comments-on” paper is published on arXiv, a reply from the authors of the original paper is always permitted (subject to the same moderation criteria as comments). Reply submissions should include the arXiv-ID of the “comments-on” paper to which they respond in the Title and/or Comments metadata fields (e.g., “reply to arXiv: YYMM.NNNNN”).
+- When a “comments-on” paper is posted on arXiv, a reply from the authors of the original paper is permitted (subject to the same moderation criteria as comments). Reply submissions should include the arXiv-ID of the “comments-on” paper to which they respond in the Title and/or Comments metadata fields (e.g., “reply to arXiv: YYMM.NNNNN”).
 - In rare cases where the original paper is not on arXiv, the DOI of the original paper should be used to identify it in the metadata in place of an arXiv-ID.
 - A chain of continued responses and counterresponses is allowed only as new versions of the initial Comment and Reply; these will not be accepted as new papers with new arXiv-IDs. A given author or co-author may submit only one Comment on a particular paper. Any subsequent issues the author wishes to raise must be done through version updates of the original Comment.
 


### PR DESCRIPTION
Rephrasing the bullet points under "Comments and Replies to Comments" subheading to better describe the metadata requirements for these submission types.