### PR TITLE
Corrected link and verbiage on API info pages

### DIFF
--- a/source/help/api/tou.md
+++ b/source/help/api/tou.md
@@ -39,7 +39,7 @@ this page.
   something illegal or unethical, we may further limit or block your access.
 - You understand that we will make changes to arXiv APIs that may lead to
   compatibility issues with your code. We will do our best to provide advance
-  notice of such changes via our [website](https://api.arxiv.org) and the
+  notice of such changes via our [website](https://arxiv.org/) under arXiv News and the
   [arXiv API group](https://groups.google.com/forum/#!forum/arxiv-api). It is
   up to you to keep track of changes that might affect your use of arXiv APIs
   and to make any required changes.

--- a/source/help/api/user-manual.md
+++ b/source/help/api/user-manual.md
@@ -251,16 +251,16 @@ the query. For example, if wanted to step through the results of a
 Detailed examples of how to perform paging in a variety of programming
 languages can be found in the [examples](#detailed_examples) section.
 
-<sup>In cases where the API needs to be called multiple times in a row, we encourage you to play nice and incorporate a 3 second delay in your code. The [detailed examples](#detailed_examples) below illustrate how to do this in a variety of languages. </sup>
+In cases where the API needs to be called multiple times in a row, we encourage you to play nice and incorporate a 3 second delay in your code. The [detailed examples](#detailed_examples) below illustrate how to do this in a variety of languages. 
 
 
-<sup>Because of speed limitations in our implementation of the API, the
+Because of speed limitations in our implementation of the API, the
 maximum number of results returned from a single call (`max_results`) is
 limited to 30000 in slices of at most 2000 at a time, using the
 `max_results` and `start` query parameters. For example to retrieve
 matches 6001-8000:
-http://export.arxiv.org/api/query?search_query=all:electron&start=6000&max_results=8000
-</sup>
+http://export.arxiv.org/api/query?search_query=all:electron&start=6000&max_results=2000
+
 
 Large result sets put considerable load on the server and also take a
 long time to render. We recommend to refine queries which return more

--- a/source/help/policies/content-types.md
+++ b/source/help/policies/content-types.md
@@ -78,7 +78,7 @@ Please refer to the page on [Translations](/help/translations.html)
 
 <a name="Comments"></a>
 
-## Comments and Reply to Comments
+## Comments and Replies to Comments
 
 arXiv encourages dialogue and debate about scientific matters. Normally this occurs via a series of papers that build on or critically examine each other. These are moderated each individually as standalone papers. Sometimes, a remark on or note about another paper that is not a full standalone paper is of sufficient interest to arXiv readers. These can be put on arXiv as so-called "comments-on" papers. All normal moderation criteria apply to these, except that they need not be complete standalone papers.
 

--- a/source/help/policies/content-types.md
+++ b/source/help/policies/content-types.md
@@ -84,9 +84,9 @@ arXiv encourages dialogue and debate about scientific matters. Normally this occ
 
 Requirements for Comments and Replies:
 
-- "Comments-on" content type must have a Title: "Comment(s) on 'title-of-original-paper'" and the metadata Comments field must contain "comment(s) on arXiv-ID-of-the-original-paper".
-- A response from the original authors is always permitted and must have a Title: "Reply to comment(s) on 'title-of-original-paper'" and the Comments metadata field must contain "reply to comment(s) on arXiv-ID".
-- In rare cases where the original paper is not on arXiv the arXiv-ID is replaced by the external DOI.
+- “Comments-on” papers must include the arXiv-ID of the original paper in the Title and/or Comments metadata fields (e.g., “comment(s) on arXiv:YYMM.NNNNN").
+- When a “comments-on” paper is posted on arXiv, a reply from the authors of the original paper is permitted (subject to the same moderation criteria as comments). Reply submissions should include the arXiv-ID of the “comments-on” paper to which they respond in the Title and/or Comments metadata fields (e.g., “reply to arXiv: YYMM.NNNNN”).
+- In rare cases where the original paper is not on arXiv, the DOI of the original paper should be used to identify it in the metadata in place of an arXiv-ID.
 - A chain of continued responses and counterresponses is allowed only as new versions of the initial Comment and Reply; these will not be accepted as new papers with new arXiv-IDs. A given author or co-author may submit only one Comment on a particular paper. Any subsequent issues the author wishes to raise must be done through version updates of the original Comment.
 
   * A replacement can be used two ways to create a new version under the same arXiv-ID:


### PR DESCRIPTION
1. Corrected link on API Terms of Use page

2. Corrected a typo in an API query to limit results to 2000.