### PR TITLE
Fix affiliation name

### DIFF
--- a/source/help/cs/index.md
+++ b/source/help/cs/index.md
@@ -10,7 +10,7 @@ The [moderators for the computer science archive are listed here](https://arxiv.
 
 The editorial committee members serve as consultants to Cornell University and to the arXiv [Editorial Advisory Council](../../about/people/editorial_advisory_council.md). All arXiv policy decisions are ultimately made by Cornell University.
 
-- Thomas Dietterich, University of Oregon (chair)
+- Thomas Dietterich, Oregon State University (chair)
 - Krzysztof Apt, Centrum Wiskunde & Informatica, and University of Amsterdam
 - Ron Boisvert, National Institute of Standards and Technology
 - Carol Hutchins, New York University


### PR DESCRIPTION
University of Oregon and Oregon State University are two distinct institutions. See: https://engineering.oregonstate.edu/people/thomas-g-dietterich