### PR TITLE
Ccameron institutional report 2023

### DIFF
--- a/source/about/reports/2023_institution_submissions.md
+++ b/source/about/reports/2023_institution_submissions.md
@@ -1,0 +1,18 @@
+
+# Submissions by Institution (2023)
+
+_See more [arXiv in Numbers](2022_usage.md)_
+
+Submissions by Institution will be made available to members only by June 2023.
+
+The following table shows submissions by institution in 2020, 2021, and 2022. To search for a specific institution, hover your mouse over the right hand corner of the list of institutions to reveal the search icon. [To learn how this information is used in the membership program, see here](../../about/membership.md).
+
+<link href="https://cdn.datatables.net/2.1.2/css/dataTables.dataTables.css" rel="stylesheet" type="text/css">
+<script type='text/javascript' src="https://code.jquery.com/jquery-3.7.1.js"></script>
+<script type='text/javascript' src="https://cdn.datatables.net/2.1.2/js/dataTables.js"></script>
+<script type='text/javascript' src="https://storage.googleapis.com/info-arxiv-org-stats/test_data_table.js"></script>
+
+<table id="example" class="display" width="100%"></table>
+
+Data provided by
+<img width="44" style="vertical-align:middle" src='https://arxiv.org/scopus.png'/>

--- a/source/about/reports/2023_institution_submissions.md
+++ b/source/about/reports/2023_institution_submissions.md
@@ -7,9 +7,8 @@
 
 _See more [arXiv in Numbers](2023_usage.md)_
 
-Submissions by Institution will be made available to members only by June 2023.
+Submissions by Institution will be made available to members only by June 2023. [To learn how this information is used in the membership program, see here](../../about/membership.md). The following table shows submissions by institution in 2021, 2022, and 2023. Don't see your institution? Contact [membership@arxiv.org](mailto:membership.arxiv.org). 
 
-The following table shows submissions by institution in 2021, 2022, and 2023. To search for a specific institution, hover your mouse over the right hand corner of the list of institutions to reveal the search icon. [To learn how this information is used in the membership program, see here](../../about/membership.md).  
 
 <style>
 
@@ -53,18 +52,19 @@ The following table shows submissions by institution in 2021, 2022, and 2023. To
 
 <div class="filters-wrapper">
     <div class="filter-item">
-        <h3>Institution</h3> 
+        <h4>Institution Name</h4> 
         <div class="filters-container" id="institution-filter-container">
             <div id="institution-filter"></div>
         </div>
     </div>
     <div class="filter-item">
-        <h3>Country</h3>
+        <h4>Country</h4>
         <div class="filters-container" id="country-filter-container">
             <div id="country-filter"></div>
         </div>
     </div>
 </div>
+
 <div id="institution_rank_wrapper" style="max-width: 1200px;">
     <table id="institution_rank" class="display compact"></table>
 </div>

--- a/source/about/reports/2023_institution_submissions.md
+++ b/source/about/reports/2023_institution_submissions.md
@@ -1,18 +1,20 @@
 
+<script type='text/javascript' src="https://code.jquery.com/jquery-3.7.1.js"></script>  
+<script type='text/javascript' src="https://cdn.datatables.net/2.1.2/js/dataTables.js"></script>  
+<script type='text/javascript' src="https://storage.googleapis.com/info-arxiv-org-stats/test_data_table.js"></script>  
+<link href="https://cdn.datatables.net/2.1.2/css/dataTables.dataTables.css" rel="stylesheet" type="text/css">  
+
 # Submissions by Institution (2023)
 
-_See more [arXiv in Numbers](2022_usage.md)_
+_See more [arXiv in Numbers](2023_usage.md)_
 
 Submissions by Institution will be made available to members only by June 2023.
 
-The following table shows submissions by institution in 2020, 2021, and 2022. To search for a specific institution, hover your mouse over the right hand corner of the list of institutions to reveal the search icon. [To learn how this information is used in the membership program, see here](../../about/membership.md).
+The following table shows submissions by institution in 2021, 2022, and 2023. To search for a specific institution, hover your mouse over the right hand corner of the list of institutions to reveal the search icon. [To learn how this information is used in the membership program, see here](../../about/membership.md).  
 
-<link href="https://cdn.datatables.net/2.1.2/css/dataTables.dataTables.css" rel="stylesheet" type="text/css">
-<script type='text/javascript' src="https://code.jquery.com/jquery-3.7.1.js"></script>
-<script type='text/javascript' src="https://cdn.datatables.net/2.1.2/js/dataTables.js"></script>
-<script type='text/javascript' src="https://storage.googleapis.com/info-arxiv-org-stats/test_data_table.js"></script>
+  
 
-<table id="example" class="display" width="100%"></table>
+<table id="example" class="table datatable display" width="100%" onload=""></table>  
 
 Data provided by
-<img width="44" style="vertical-align:middle" src='https://arxiv.org/scopus.png'/>
+<img width="44" style="vertical-align:middle" src='https://arxiv.org/scopus.png'/>  

--- a/source/about/reports/2023_institution_submissions.md
+++ b/source/about/reports/2023_institution_submissions.md
@@ -1,7 +1,6 @@
 
 <script type='text/javascript' src="https://code.jquery.com/jquery-3.7.1.js"></script>  
 <script type='text/javascript' src="https://cdn.datatables.net/2.1.2/js/dataTables.js"></script>  
-<script type='text/javascript' src="https://storage.googleapis.com/info-arxiv-org-stats/test_data_table.js"></script>  
 <link href="https://cdn.datatables.net/2.1.2/css/dataTables.dataTables.css" rel="stylesheet" type="text/css">  
 
 # Submissions by Institution (2023)
@@ -12,9 +11,8 @@ Submissions by Institution will be made available to members only by June 2023.
 
 The following table shows submissions by institution in 2021, 2022, and 2023. To search for a specific institution, hover your mouse over the right hand corner of the list of institutions to reveal the search icon. [To learn how this information is used in the membership program, see here](../../about/membership.md).  
 
-  
-
-<table id="example" class="table datatable display" width="100%" onload=""></table>  
+<table id="institution_rank" class="table datatable display" width="100%"></table>  
+<script type='text/javascript' src="https://storage.googleapis.com/info-arxiv-org-stats/institution_submissions.js"></script>
 
 Data provided by
 <img width="44" style="vertical-align:middle" src='https://arxiv.org/scopus.png'/>  

--- a/source/about/reports/2023_institution_submissions.md
+++ b/source/about/reports/2023_institution_submissions.md
@@ -11,8 +11,67 @@ Submissions by Institution will be made available to members only by June 2023.
 
 The following table shows submissions by institution in 2021, 2022, and 2023. To search for a specific institution, hover your mouse over the right hand corner of the list of institutions to reveal the search icon. [To learn how this information is used in the membership program, see here](../../about/membership.md).  
 
-<table id="institution_rank" class="table datatable display" width="100%"></table>  
-<script type='text/javascript' src="https://storage.googleapis.com/info-arxiv-org-stats/institution_submissions.js"></script>
+<style>
+
+    .filters-wrapper {
+        display: flex;
+        flex-direction: row;
+        margin-bottom: 20px;
+    }
+
+    /* Clear floats after the columns */
+    .filters-wrapper:after {
+    content: "";
+    display: table;
+    clear: both;
+    }
+
+    .filters-container {
+        max-height: 200px;
+        overflow-y: auto;
+        border: 1px solid #ccc;
+        padding: 10px;
+        font-size: .9em;
+        float: left;
+    }
+
+    .filter-item {
+        margin-right: 20px;
+        width: 50%;
+    }
+
+    table.dataTable {
+        margin: 0 auto;
+        font-size: .9em; 
+    }
+
+    table.dataTable thead th {
+        white-space: nowrap;
+    }
+
+</style>
+
+<div class="filters-wrapper">
+    <div class="filter-item">
+        <h3>Institution</h3> 
+        <div class="filters-container" id="institution-filter-container">
+            <div id="institution-filter"></div>
+        </div>
+    </div>
+    <div class="filter-item">
+        <h3>Country</h3>
+        <div class="filters-container" id="country-filter-container">
+            <div id="country-filter"></div>
+        </div>
+    </div>
+</div>
+<div id="institution_rank_wrapper" style="max-width: 1200px;">
+    <table id="institution_rank" class="display compact"></table>
+</div>
+
+
+<script type='text/javascript' src="https://storage.googleapis.com/info-arxiv-org-stats/institution_submissions_top_filter_v10.js"></script>
 
 Data provided by
 <img width="44" style="vertical-align:middle" src='https://arxiv.org/scopus.png'/>  
+


### PR DESCRIPTION
Adds a 2023 institutional ranking page. There are no current links to the page. I need to see if pulling the content from gcloud works on production. 