### PR TITLE
releasing fix to reported broken link on info submit page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ mkdocs-literate-nav==0.5.0
 mkdocs-material==8.5.6
 mkdocs-material-extensions==1.0.3
 packaging==21.3
-Pygments==2.13.0
+Pygments==2.15.0
 pymdown-extensions==10.0
 pyparsing==3.0.9
 python-dateutil==2.8.2

--- a/source/help/submit/index.md
+++ b/source/help/submit/index.md
@@ -17,7 +17,7 @@ Submissions to arXiv should be topical and refereeable scientific contributions 
 
 -   [Formats for text submission](#text)
 -   [Formats for figures](#figures)
--   [Policies for format requirements](help/policies/format_requirements.md)
+-   [Policies for format requirements](../policies/format_requirements.md)
 -   [File names and case sensitivity](#files)
 -   [Inclusion of data sets and ancillary files (data, programs,
     etc.)](#datasets)


### PR DESCRIPTION
To Reproduce
Steps to reproduce the behavior:

Go to ['[...'](https://info.arxiv.org/help/submit/index.html#text)](https://info.arxiv.org/help/submit/index.html#text)
Click on [Policies for format requirements](https://info.arxiv.org/help/submit/help/policies/format_requirements.md)
See error 404