### PR TITLE
merging corrected feedparser link to prod

### DIFF
--- a/source/help/api/user-manual.md
+++ b/source/help/api/user-manual.md
@@ -801,7 +801,7 @@ languages above, as well as to the libraries used to parse Atom.
 |:---------|:-------------------------------------------------------------|:-----------------------------------------------------|:---------------------------------------------------|
 | Language | Library                                                      | Parsing Example                                      | Paging Example                                     |
 | Perl     | [XML::Atom](http://search.cpan.org/~miyagawa/XML-Atom-0.27/) | [parsing](examples/perl_arXiv_parsing_example.txt)   | [paging](examples/perl_arXiv_paging_example.txt)   |
-| Python   | [feedparser](http://feedparser.org/)                         | [parsing](examples/python_arXiv_parsing_example.txt) | [paging](examples/python_arXiv_paging_example.txt) |
+| Python   | [feedparser](https://github.com/kurtmckee/feedparser)                          | [parsing](examples/python_arXiv_parsing_example.txt) | [paging](examples/python_arXiv_paging_example.txt) |
 | Ruby     | [feedtools](http://sporkmonger.com/2005/08/11/tutorial)      | [parsing](examples/ruby_arXiv_parsing_example.txt)   | [paging](examples/ruby_arXiv_paging_example.txt)   |
 | PHP      | [SimplePie](http://simplepie.org/)                           | [parsing](examples/php_arXiv_parsing_example.txt)    | [paging](examples/php_arXiv_paging_example.txt)    |
 

--- a/source/help/physics/index.md
+++ b/source/help/physics/index.md
@@ -33,6 +33,7 @@ The advisory committee members serve as consultants to Cornell University and to
 - Axel Naumann, CERN
 - Susan Ramlo, University of Akron
 - Chris Reynolds, University of Maryland
+- Sakura Schafer-Nameki, University of Oxford
 - Rena Zieve, University of California, Davis
 
 ## Historical notes


### PR DESCRIPTION
[Bad link for Python API package feedparser](https://github.com/arXiv/arxiv-docs/commit/036763b39dd8e520312b0f1928e2b077c777cf62) https://github.com/arXiv/arxiv-docs/issues/999 