### PR TITLE
Corrected page title in left nav

### DIFF
--- a/source/SUMMARY.md
+++ b/source/SUMMARY.md
@@ -71,7 +71,7 @@
      * [Identity, affiliation, and registration](help/policies/identity_and_affiliation.md)
      * [Submission terms and agreement](help/policies/submission_agreement.md)
      * [Paper ownership](help/authority.md)
-     * [General submission policies](help/submit/index.md)
+     * [Submission Guidelines](help/submit/index.md)
      * [Submission schedule and cutoff time](help/availability.md)
      * [Content Moderation](help/moderation/index.md)
      * [License and copyright](help/license/index.md)


### PR DESCRIPTION
The Submission Guidlines page was incorrectly titled as "General submission policies" in the left navigation. When searching in google, the page would come up as "General Submission Policies" as a result rather than "Submission Guidelines".