### PR TITLE
Arxivce 2972 labs page u pdates

### DIFF
--- a/source/labs/index.md
+++ b/source/labs/index.md
@@ -2,16 +2,18 @@
 
 ![arXiv Labs icon](images/smileybones-labs-icon.png){.mkd-img-thumb align=right alt='a bubbling beaker with a smiling face and crossedbones behind it' role=presentation}
 
-arXivLabs allows the community to contribute to arXiv by integrating code into the arXiv platform to provide features such as bibliographic tools and demos. These integrations are available  to readers through a series of tabs at the bottom of the abstract page.
+We welcome proposals from the community for arXivLabs integrations. Proposed features must **add value to arXiv content, benefits the scientific community,** and be based on underlying services that are **free of charge** or operate on a freemium model.
 
 ![arXiv Labs features](images/arXivLabsFeatures-01.png)
 
 
-We welcome proposals from the community for arXivLabs integrations. Proposed features must add value to arXiv content, benefit the scientific community, and be based on underlying services that are free of charge or operate on a freemium model. Please note that Labs projects may be removed at any time at the sole discretion of arXiv. As a courtesy, arXiv will notify the creator when possible that their integration has been removed.
+arXiv Labs lets the community contribute new, useful features to arXiv. These integrations are available to readers through a series of tabs at the bottom of the abstract page. 
 
-If you wish to submit a proposal for an arXivLabs project, please review our proposal criteria below before doing so. After you have reviewed our criteria, follow the steps provided at the end of this page for submitting a proposal. As part of your proposal, you will need to submit a Pull Request (PR). The final decision for approving an arXivLabs project is made by the arXiv management and teams.
+Useful feature include bibliographic info, demos, and links to code. Explore arXiv abstract pages or the Labs Showcase to see examples.
 
-**arXivLabs is not:**
+To submit, review our proposal criteria below and then follow the steps at the end of this page. Note that the final decision for approving an arXivLabs project is made by arXiv management and teams.
+
+#### arXivLabs is not: ####
 
 - A source of research funding.
 - The venue for proposing formal collaboration with arXiv.
@@ -42,17 +44,17 @@ We encourage all contributors to Labs to continue to update and maintain their c
 
 #### UI/UX
 
-- Projects with user-facing components must adopt [WCAG 2.0](http://www.w3.org/TR/2008/REC-WCAG20-20081211/) Level A (Web Content Accessibility Guidelines). Higher levels of accessibility (i.e. AA, AAA) are encouraged and welcome.
+- Projects with user-facing components must adopt [WCAG 2.1, level AA](https://www.w3.org/TR/WCAG21/) Level A (Web Content Accessibility Guidelines). Higher levels of accessibility (i.e. AAA) are encouraged and welcome.
 - Any user-facing or promotional content must clearly indicate that the project is an arXivLabs project.
 - As an arXiv-affiliated project, naming, content, and graphical elements must be consistent with the norms of professional conduct, including the arXiv Code of Conduct and [Brand and Style Guide](../brand/index.md).
-  - Except when specifically authorized in writing, the use of the name “arXiv” or “arXiv.org” is prohibited in non-arXiv organization names or projects, advertising and other promotional vehicles.
-- When practical, a quick-to-use Likert-style or cardinal feedback mechanism should be made available.
+  - The use of the name “arXiv”, “arXiv.org”, and our logo are prohibited and protected by copyright and registered trademarks. Use of our name and logo, except to acknowledge arXiv, is prohibited - except when specifically authorized in writing.
+  - When Labs projects use arXiv’s logo or name in an unauthorized manner it confuses users and adds to arXiv’s heavy user feedback load.
 
 #### Security & Privacy
 - Projects with UI components are reviewed for vulnerabilities that might put users or the arXiv platform itself at risk or leak user information. In cases where vulnerabilities are discovered, Labs partners will be responsible for correcting the issue or risk having their project rejected or terminated.
 - The PR must contain all the code that is to be run on the abs page for the project integration. It must not load code from any other source, or for any other purpose.
 - Projects must not circumvent or undermine existing security or quality of service measures on the arXiv platform.
-- A feedback collection mechanism of some kind must be made available to end users. For example, a JIRA feedback collector may be used to collect qualitative feedback.
+- A feedback collection mechanism of some kind for end users is recommended. 
 
 ## Submit Your Proposal
 

--- a/source/labs/index.md
+++ b/source/labs/index.md
@@ -44,11 +44,11 @@ We encourage all contributors to Labs to continue to update and maintain their c
 
 #### UI/UX
 
-- Projects with user-facing components must adopt [WCAG 2.1, level AA](https://www.w3.org/TR/WCAG21/) Level A (Web Content Accessibility Guidelines). Higher levels of accessibility (i.e. AAA) are encouraged and welcome.
+- Projects with user-facing components must adopt [WCAG 2.1](https://www.w3.org/TR/WCAG21/) Level AA (Web Content Accessibility Guidelines). Higher levels of accessibility (i.e. AAA) are encouraged and welcome.
 - Any user-facing or promotional content must clearly indicate that the project is an arXivLabs project.
 - As an arXiv-affiliated project, naming, content, and graphical elements must be consistent with the norms of professional conduct, including the arXiv Code of Conduct and [Brand and Style Guide](../brand/index.md).
-  - The use of the name “arXiv”, “arXiv.org”, and our logo are prohibited and protected by copyright and registered trademarks. Use of our name and logo, except to acknowledge arXiv, is prohibited - except when specifically authorized in writing.
-  - When Labs projects use arXiv’s logo or name in an unauthorized manner it confuses users and adds to arXiv’s heavy user feedback load.
+  - The use of the name “arXiv”, “arXiv.org”, and our logo are protected by copyright and registered trademarks. Use of our name and logo, except to acknowledge arXiv, is prohibited.
+  - When Labs projects use arXiv’s name or logo in an unauthorized manner it confuses users and adds to arXiv’s heavy user feedback load.
 
 #### Security & Privacy
 - Projects with UI components are reviewed for vulnerabilities that might put users or the arXiv platform itself at risk or leak user information. In cases where vulnerabilities are discovered, Labs partners will be responsible for correcting the issue or risk having their project rejected or terminated.

--- a/source/labs/index.md
+++ b/source/labs/index.md
@@ -2,7 +2,7 @@
 
 ![arXiv Labs icon](images/smileybones-labs-icon.png){.mkd-img-thumb align=right alt='a bubbling beaker with a smiling face and crossedbones behind it' role=presentation}
 
-We welcome proposals from the community for arXivLabs integrations. Proposed features must **add value to arXiv content, benefits the scientific community,** and be based on underlying services that are **free of charge** or operate on a freemium model.
+We welcome proposals from the community for arXivLabs integrations. Proposed features must **add value to arXiv content, benefit the scientific community,** and be based on underlying services that are **free of charge** or operate on a freemium model.
 
 ![arXiv Labs features](images/arXivLabsFeatures-01.png)
 


### PR DESCRIPTION
- Adjust language to less dissuasive
- 
- Instead of bolding text to look like a header, use headers like <h4>.
- 
- _A feedback collection mechanism of some kind must be made available to end users. For example, a JIRA feedback collector may be used to collect qualitative feedback._ Remove “must” and second sentence.
- 
- Update the accessibility criteria to WCAG 2.1 Level AA. This is the current guideline from Cornell and what is required by law.
- 
- Add a note about use of the logo, alongside guidance on use of the name. Something like “arXiv,[ arXiv.org](http://arxiv.org/), and our logo are protected by copyright and registered trademarks. Use of our name and logo, except to acknowledge arXiv, is prohibited.
- 
- We might want to explain further that “when Labs projects use arXiv’s logo or name in an unauthorized manner it confuses users and adds to arXiv’s heavy user feedback load.”