### PR TITLE
Arxivce 2970 update eac and iac content

### DIFF
--- a/source/about/people/editorial_advisory_council.md
+++ b/source/about/people/editorial_advisory_council.md
@@ -11,6 +11,8 @@ reproducible procedures for arXiv, that leave room for editorial judgement of co
 
 **Ralph Wijers (Chair, 2023-2026)**, Professor of High-Energy Astrophysics, University of Amsterdam (chair of arXiv Physics Editorial Committee)
 
+**Thomas Dietterich (Vice Chair, 2023-2026)**, Distinguished Professor Emeritus and CoRIS Associate Director of Policy, University of Oregon (chair of arXiv Computer Science Editorial Committee)
+
 **Arthur M. Berd (2023-2026)**, Founder and CEO, General Quantitative and 
 Editor-in-Chief, Journal of Investment Strategies (co-chair of arXiv Quantitative Finance Editorial Committee)
 
@@ -18,8 +20,6 @@ Editor-in-Chief, Journal of Investment Strategies (co-chair of arXiv Quantitativ
 
 **Ralf Bundschuh (2023-2026)**, Professor of Physics, Chemistry & Biochemistry, and Hematology, The Ohio State University 
 (chair of arXiv Quantitative Biology Editorial Commitee)
-
-**Thomas Dietterich (2023-2026)**, Distinguished Professor Emeritus and CoRIS Associate Director of Policy, University of Oregon (chair of arXiv Computer Science Editorial Committee)
 
 **Paul Gunnells (2023-2026)**, Professor of Mathematics, University of Massachusetts (chair of arXiv Mathematics Science Editorial Committee)
 

--- a/source/about/people/editorial_advisory_council.md
+++ b/source/about/people/editorial_advisory_council.md
@@ -11,7 +11,7 @@ reproducible procedures for arXiv, that leave room for editorial judgement of co
 
 **Ralph Wijers (Chair, 2023-2026)**, Professor of High-Energy Astrophysics, University of Amsterdam (chair of arXiv Physics Editorial Committee)
 
-**Thomas Dietterich (Vice Chair, 2023-2026)**, Distinguished Professor Emeritus and CoRIS Associate Director of Policy, University of Oregon (chair of arXiv Computer Science Editorial Committee)
+**Thomas Dietterich (Vice Chair, 2025-2026)**, Distinguished Professor Emeritus and CoRIS Associate Director of Policy, University of Oregon (chair of arXiv Computer Science Editorial Committee)
 
 **Arthur M. Berd (2023-2026)**, Founder and CEO, General Quantitative and 
 Editor-in-Chief, Journal of Investment Strategies (co-chair of arXiv Quantitative Finance Editorial Committee)

--- a/source/about/people/institutions_advisory_council.md
+++ b/source/about/people/institutions_advisory_council.md
@@ -23,6 +23,11 @@ responds to such input.
 
 Maureen P. Walsh is the Scholarly Sharing Strategist and an Associate Professor at The Ohio State University Libraries. She has been actively involved with the open repository community for 17 years and is currently the Chair of the DSpace Steering and Leadership Groups and a standing member of the Open Repositories Steering Committee.
 
+**Alex Kohls (Vice Chair, 2025-2027),** representing CERN, Switzerland
+
+Alex heads the CERN Scientific Information Service, a central unit for the management and dissemination of the laboratories‘ research output. His responsibilities include the CERN Library and CERN's historical archives as well as a portfolio of institutional and international open science activities, such as SCOAP3. In collaboration with other institutions, Alex‘ team also develops and operates some of the key digital repository solutions for particle physics and participates in international policy efforts. He joined CERN initially as the SCOAP3 Operations Manager coordinating the world’s largest Open Access collaborative over its initial 5 years. 
+Alex holds a degree in business administration and joined CERN with 20 years experience from the financial industry where he worked in various senior roles primarily in operations, controlling, and project management.
+
 **Clare Appavoo (Member, 2023-2026),** representing the Canadian Research Knowledge Network (CRKN), Canada
 
 **Tracey Clarke (Member, 2023-2026),** representing Jisc, United Kingdom
@@ -38,13 +43,6 @@ Robert is a member of the AMS leadership team, and has the overall responsibilit
 **Martin Kohler (Member, 2023-2026),** representing Consortium arXiv-DH and HGF, Germany
 
 Martin heads the Deutsches Elektronen-Synchrotron and European X-Ray Free-Electron Laser libraries including DESY’s institutional repository, open access and publishing house. He holds a doctorate in physics from the university of Hamburg.
-
-
-
-**Alex Kohls (Vice Chair, April - December 31, 2024) (Member, 2023-2026),** representing CERN, Switzerland
-
-Alex heads the CERN Scientific Information Service, a central unit for the management and dissemination of the laboratories‘ research output. His responsibilities include the CERN Library and CERN's historical archives as well as a portfolio of institutional and international open science activities, such as SCOAP3. In collaboration with other institutions, Alex‘ team also develops and operates some of the key digital repository solutions for particle physics and participates in international policy efforts. He joined CERN initially as the SCOAP3 Operations Manager coordinating the world’s largest Open Access collaborative over its initial 5 years. 
-Alex holds a degree in business administration and joined CERN with 20 years experience from the financial industry where he worked in various senior roles primarily in operations, controlling, and project management.
 
 **Hideaki Takeda (Member, 2023-2026),** representing Japan NII Consortia, Japan
 


### PR DESCRIPTION
As of Jan. 1 Thomas Dietterich is vice chair of the EAC. Please add that information the page: https://info.arxiv.org/about/people/editorial_advisory_council.html

  His term is 2025-2027  Alex Kohls is listed as Vice Chair of IAC for April to December 2024. He has now been appointed to a full three year term. Please update the IAC page to indicate that he is vice chair for 2025-2027.  https://info.arxiv.org/about/people/institutions_advisory_council.html