### PR TITLE
Removes broken link to labs showcase

### DIFF
--- a/source/labs/index.md
+++ b/source/labs/index.md
@@ -10,7 +10,7 @@ We welcome proposals from the community for arXivLabs integrations. Proposed fea
 > arXiv Labs lets the community contribute new, useful features to arXiv. These integrations are available to readers through a series of tabs at the bottom of the abstract page. 
 > <img src="images/arXivLabsFeatures-01.png" width="400" align="left">
 > 
-> Useful feature include bibliographic info, demos, and links to code. Explore arXiv abstract pages or the [Labs Showcase](/source/labs/showcase.md) to see examples.
+> Useful feature include bibliographic info, demos, and links to code. Explore arXiv abstract pages to see examples.
 > 
 > To submit, review our proposal criteria below and then follow the steps at the end of this page. Note that the final decision for approving an arXivLabs project is made by arXiv management and teams.
 ><p></p>


### PR DESCRIPTION
https://info.arxiv.org/source/labs/showcase.md.html is 404, this PR removes it.