### PR TITLE
line break added to fix anchor link

### DIFF
--- a/source/help/faq/mistakes.md
+++ b/source/help/faq/mistakes.md
@@ -502,7 +502,8 @@ programs that rely on proper DSC structure when two or more such files
 are included in each other.
 
 
-<span id="mixed"></span> ## Mixed figure file formats
+<span id="mixed"></span>
+## Mixed figure file formats
 
 arXiv does not perform any "on the fly" figure file conversions from PostScript to PDF, so your
 figure files must be in the same format expected for your processing engine. This means PDFLATeX would accept any combination of `.pdf`, `.jpg`, and/or `.png`, and that (La)TeX accepts `.ps` and/or `.eps` only. You can tell this has been done locally because the converted figures will typically appear with names like "`-eps-converted-to.pdf`" in addition to the original `.eps` file.

--- a/source/help/submit/index.md
+++ b/source/help/submit/index.md
@@ -22,6 +22,7 @@ Submissions to arXiv should be topical and refereeable scientific contributions 
 -   [Inclusion of data sets and ancillary files (data, programs,
     etc.)](#datasets)
 -   [Title and abstract preparation](#prep)
+-   [Upload and prepare your submission files](#)
 -   [Verify and correct your submission](#correct)
 -   [Edit or replace your submission](#replace)
 
@@ -103,6 +104,54 @@ abstract pages, in announcements, in RSS feeds, and to support
 searching.
 
 <span id="correct"></span>
+
+## Upload and prepare your submission file
+
+To submit an article, select the "START NEW SUBMISSION" button. 
+
+### Submission v1.5
+
+The following instructions will guide you through version 1.5 of our submission system when you select “START NEW SUBMISSION v1.5" from your [user page](https://arxiv.org/user).
+
+1. On the **Prepare Files** page click on **Choose File**.
+    - Select the file(s) you wish to upload. You can use zip or tar.gz to upload multiple files, uploading source that uses subfolders, and source that includes ancillary files. 
+        - Please note: The option to drag files from your computer into the submission window in the browser is not currently available.
+
+    - Click **Upload**.
+    - The screen will refresh and will display the files that have been uploaded. 
+    - Review your files and delete any files that may not be necessary.
+    - Click on the trashcan icon to delete single files.
+    - If you would like to start over, click on **Delete All** to delete all the files and start the upload process again.
+
+2. Once you have reviewed your uploaded files, click **Check Files**.
+    - Your files will be analyzed  to identify the correct processor, the top level TeX file, and any potential extraneous files for deletion.
+
+3. Notice which compiler was auto detected. 
+    - Use the dropdown menu if you would like to select a different compiler.
+
+4. Note which file was auto-detected as the **Top-Level TeX** file.
+    - Use the dropdown menu if you would like to select a different file Top-Level TeX file.
+    - Only TeX files containing \documentclass directives will be shown on this list. You may choose multiple Top-Level files and the resulting article will contain the TeX output of all the selected files, concatenated together, in order. 
+
+5. Carefully review the Auto-detected Notes for the files.
+    - Note which files are recommended for deletion.
+        - Uncheck if the file should not be deleted.
+        - If at any point you would like to start over with your submission, you may click on the **Return to Upload Step**.
+
+6. **Click Accept and Continue**.
+    - A pop up window will prompt you to confirm the files you want to delete.
+
+7. Click **Confirm**.
+
+8. The next page will display if your file compiled successfully and the compilation log. 
+    - If your file compiled successfully, you may **Preview your PDF**.
+    - Click **Continue** to proceed to the Metadata page. 
+    - If your file does not compile successfully and you receive an error, please review your submission for the five most common mistakes made when submitting papers: 
+        - Mixed figure file formats. If you are using PDFLaTeX then all figures must be .pdf, .jpg, or .png formats. If your document uses (La)TeX all figures must be .ps or .eps. arXiv does not perform figure file conversion for you, please [ensure your files are converted to the appropriate format](../faq/mistake.md#mixed) before uploading.
+        - File-name [upper/lower-case mismatch](../faq/mistakes.md#case_filenames) between TeX source and figure or included files. arXiv's file system is case sensitive.
+        - Default hyperref failures ("Option clash for package hyperref") are not a reason to report a failure to arXiv. Continue scrolling in the log to find the specific errors that are being flagged.
+        - Missing customized or differing version of [style files](../faq/mistakes.md#missing_macro).
+        - Missing, misnamed, or local complete paths to [figure files](../faq/mistakes.md#abs_filenames). arXiv's file system is case sensitive.
 
 ## Verify and correct your submission
 


### PR DESCRIPTION
The lack of line break broke the anchor link in markdown. I needed to fix this before I complete adding my GenPDF documentation due to a link that references that borked anchor. 