### PR TITLE
Updates to the S3 file size estimate

### DIFF
--- a/source/help/bulk_data_s3.md
+++ b/source/help/bulk_data_s3.md
@@ -45,10 +45,9 @@ predictable cost, and avoids putting any additional load on our servers
 that might impact interactive performance. Note that arXiv's buckets are
 located in the Eastern US (N. Virginia) region.
 
-The complete set of files as of March 2023 is about 5.6 TB. With an estimated growth rate
+The complete set of files as of April 2025 is about 9.2 TB. With an estimated growth rate
 of around 100 GB per month, we expect increased growth as the submission rate continues to
-[increase over time](https://arxiv.org/stats/monthly_submissions). The PDF files are about
-2.7 TB, with the source files making up the remaining 2.9 TB of the estimate.
+[increase over time](https://arxiv.org/stats/monthly_submissions).
 
 Bulk PDF Access
 ---------------


### PR DESCRIPTION
We have been pretty lax about updating the file sizes in the S3 buckets. The previous estimate was from 2023, so this PR updates it to April's total size. 