### PR TITLE
Update endorsement.md

### DIFF
--- a/source/help/endorsement.md
+++ b/source/help/endorsement.md
@@ -3,6 +3,8 @@ The arXiv endorsement system
 
 arXiv requires that users be *endorsed*
 before submitting their first paper to a category.
+UNLESS, their paper was referenced or cited in a conference seminar like IEEE, or published in a verified Academic Journal, recommended prior to submission.
+
 
 Why does arXiv require endorsement?
 -----------------------------------


### PR DESCRIPTION
ISuggested Revision: Section on Endorsement Exceptions
Automatic Endorsement Through Scholarly Recognition

Authors whose works have already undergone formal peer review or have been cited in major academic venues may be considered as implicitly endorsed. This includes:

Articles published in recognized academic journals.

Works referenced in proceedings of major technical or scientific conferences (e.g., IEEE, ACM).

In such cases, the endorsement serves as a technical verification mechanism—not as a gate to suppress access or participation. Authors should retain the right to disseminate scholarly contributions via arXiv when formal academic recognition already exists.

We recognize that endorsement is not a measure of quality alone, but a structural tool to protect relevance and maintain the scholarly nature of arXiv. Our goal is to ensure accessibility and academic continuity without introducing unnecessary obstacles for contributors whose work has already been evaluated by the scientific community.

