### PR TITLE
adds the docs-venv/ directory 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ celerybeat-schedule
 .venv
 venv/
 ENV/
+docs-venv/
 
 # Spyder project settings
 .spyderproject


### PR DESCRIPTION
Adds the `venv-docs` directory to the ignored `venv` list that's in the `.gitignore` file. This should prevent IDEs from trying to accidentally stage changes there as part of commits. 