### PR TITLE
arxivce-3746 Update typo and link on aaclass.md 

### DIFF
--- a/source/about/user-testing.md
+++ b/source/about/user-testing.md
@@ -1,75 +1,33 @@
 #User Experience Testing and Feedback
 
-From time to time arXiv sends out surveys, previews to new changes, invitations to be interviewed, and other testing opportunities to interested users. User experience is integral to arXiv's development process and we welcome your feedback.
+From time to time arXiv sends out surveys, previews to new changes, invitations to be interviewed, and other testing opportunities to interested users.
 {.intro}
 
-If you would like to join our user experience mailing list to learn about these opportunities, fill out the form below. We collect your contact information only for user experience-related communications and never spam or share your details.
+If you would like to take part and provide feedback please join our user experience mailing list. We will only email you with user experience-related communications and never spam or share your details.
 
-<link href="//cdn-images.mailchimp.com/embedcode/classic-10_7.css" rel="stylesheet" type="text/css">
-<style type="text/css">
-	#mc_embed_signup{background:#fff; clear:left; font-size:14px;}
-  #mc_embed_signup .mc-field-group label{font-style:normal;}
-  #mc_embed_signup .mc-field-group.input-group label{margin-left:5px;}
-  #mc_embed_signup .mc-field-group select {height:35px;}
-  @media only screen and (min-width: 600px) {
-    #mc_embed_signup{max-width:75%; margin:0 auto;}
-  }
+<div id="mc_embed_shell">
+      <link href="//cdn-images.mailchimp.com/embedcode/classic-061523.css" rel="stylesheet" type="text/css">
+  <style type="text/css">
+        #mc_embed_signup{ margin:0 auto; max-width:600px; }
+        .targeted li {margin-left:1em !important;}
+        #mc-embedded-subscribe {font-weight:bold !important;}
+        @media only screen and (min-width: 600px) {#mc_embed_signup{margin:0 auto;}}
 </style>
-<div id="mc_embed_signup">
-<h3>Join the mailing list to provide feedback and help test new user features</h3>
-<form action="https://arxiv.us4.list-manage.com/subscribe/post?u=31c4aaf571c921df1fb50adee&amp;id=7cd72795aa" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate mkd-border" target="_blank" novalidate>
-<div id="mc_embed_signup_scroll">
-<div class="mc-field-group">
-<label for="mce-EMAIL">Email Address *</label>
-<input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">
-</div>
-<div class="mc-field-group">
-<label for="mce-FNAME">First Name </label>
-<input type="text" value="" name="FNAME" class="" id="mce-FNAME">
-</div>
-<div class="mc-field-group">
-<label for="mce-LNAME">Last Name </label>
-<input type="text" value="" name="LNAME" class="" id="mce-LNAME">
-</div>
-<div class="mc-field-group">
-<label for="mce-COUNTRY">Country </label>
-<input type="text" value="" name="COUNTRY" class="" id="mce-COUNTRY">
-</div>
-<div class="mc-field-group">
-<label for="mce-RESEARCH">arXiv Research Field * </label>
-<select name="RESEARCH" class="required" id="mce-RESEARCH">
-<option value=""></option>
-<option value="Physics">Physics</option>
-<option value="Mathematics">Mathematics</option>
-<option value="Computer Science">Computer Science</option>
-<option value="Quantitative Biology">Quantitative Biology</option>
-<option value="Quantitative Finance">Quantitative Finance</option>
-<option value="Statistics">Statistics</option>
-<option value="Electrical Engineering and Systems Science">Electrical Engineering and Systems Science</option>
-<option value="Economics">Economics</option>
-<option value="Not Applicable">Not Applicable</option>
-</select>
-</div>
-<hr>
-<div class="mc-field-group input-group">
-<strong>(Optional) Targeted Testing Groups</strong>
-<p>You will be automatically added to the general user testing list. In addition we have targeted testing groups, select any that apply or leave blank. </p>
-<ul><input type="hidden" value="16" name="group[55039][16]" id="mce-group[55039]-55039-3"><li><input type="checkbox" value="1" name="group[55039][1]" id="mce-group[55039]-55039-0"><label for="mce-group[55039]-55039-0">Assistive Technology (if you use a screen reader, magnifier, voice command, or other assistive tools)</label></li>
-<li><input type="checkbox" value="2" name="group[55039][2]" id="mce-group[55039]-55039-1"><label for="mce-group[55039]-55039-1">International (if your first language is not English or first culture is not USA)</label></li>
-<li><input type="checkbox" value="4" name="group[55039][4]" id="mce-group[55039]-55039-2"><label for="mce-group[55039]-55039-2">Slow Connectivity (if you often experience slow or unreliable internet in your area)</label></li>
-<li><input type="checkbox" value="32" name="group[55039][32]" id="mce-group[55039]-55039-4"><label for="mce-group[55039]-55039-4">API Testing (if you use the arXiv API for development)</label></li>
-</ul>
-</div>
-<hr>
-<div id="mce-responses" class="clear">
-<div class="response" id="mce-error-response" style="display:none"></div>
-<div class="response" id="mce-success-response" style="display:none"></div>
-</div>
-<div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_31c4aaf571c921df1fb50adee_7cd72795aa" tabindex="-1" value=""></div>
-<div class="clear">
-<input type="submit" value="Submit and Join" name="subscribe" id="mc-embedded-subscribe" class="button">
-</div>
-</div>
+<div id="mc_embed_signup" class="mkd-border">
+    <form action="https://arxiv.us4.list-manage.com/subscribe/post?u=31c4aaf571c921df1fb50adee&amp;id=7cd72795aa&amp;f_id=00c076eaf0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank">
+        <div id="mc_embed_signup_scroll"><h3>Sign up for arXiv's user testing list</h3>
+            <div class="indicates-required"><span class="asterisk">*</span> indicates required</div>
+            <div class="mc-field-group"><label for="mce-EMAIL">Email Address <span class="asterisk">*</span></label><input type="email" name="EMAIL" class="required email" id="mce-EMAIL" required="" value=""></div><div class="mc-field-group"><label for="mce-FNAME">First Name </label><input type="text" name="FNAME" class=" text" id="mce-FNAME" value=""></div><div class="mc-field-group"><label for="mce-LNAME">Last Name </label><input type="text" name="LNAME" class=" text" id="mce-LNAME" value=""></div><div class="mc-field-group"><label for="mce-COUNTRY">Country </label><input type="text" name="COUNTRY" class=" text" id="mce-COUNTRY" value=""></div>
+            <div class="mc-field-group"><label for="mce-RESEARCH">Research field </label><select name="RESEARCH" class="" id="mce-RESEARCH"><option value=""></option><option value="Physics">Physics</option><option value="Mathematics">Mathematics</option><option value="Computer Science">Computer Science</option><option value="Quantitative Biology">Quantitative Biology</option><option value="Quantitative Finance">Quantitative Finance</option><option value="Statistics">Statistics</option><option value="Electrical Engineering and Systems Science">Electrical Engineering and Systems Science</option><option value="Economics">Economics</option><option value="Not Applicable">Not Applicable</option></select></div>
+            <hr>
+            <div class="mc-field-group input-group"><strong>Targeted Testing Groups (optional)</strong><p>You will be automatically added to the general user testing list. In addition we have targeted testing groups that may be relevant to you. Select any that apply or leave blank.</p>
+            <ul class="targeted"><li><input type="checkbox" name="group[55039][1]" id="mce-group[55039]-55039-0" value=""><label for="mce-group[55039]-55039-0">Assistive Technology (if you use a screen reader, magnifier, voice command, or other assistive tools)</label></li><li><input type="checkbox" name="group[55039][32]" id="mce-group[55039]-55039-3" value=""><label for="mce-group[55039]-55039-3">API Testing (if you use the arXiv API for development)</label></li><li><input type="checkbox" name="group[55039][2]" id="mce-group[55039]-55039-1" value=""><label for="mce-group[55039]-55039-1">International (if your first language is not English or first culture is not USA)</label></li><li><input type="checkbox" name="group[55039][4]" id="mce-group[55039]-55039-2" value=""><label for="mce-group[55039]-55039-2">Slow Connectivity (if you often experience slow or unreliable internet in your area)</label></li></ul></div>
+            <hr>
+        <div id="mce-responses" class="clear">
+            <div class="response" id="mce-error-response" style="display: none;"></div>
+            <div class="response" id="mce-success-response" style="display: none;"></div>
+        </div><div aria-hidden="true" style="position: absolute; left: -5000px;"><input type="text" name="b_31c4aaf571c921df1fb50adee_7cd72795aa" tabindex="-1" value=""></div><div class="clear"><input type="submit" name="subscribe" id="mc-embedded-subscribe" class="button" value="Sign Up"></div>
+    </div>
 </form>
 </div>
-<script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';fnames[6]='COUNTRY';ftypes[6]='text';fnames[3]='RESEARCH';ftypes[3]='dropdown';fnames[4]='CLASS';ftypes[4]='text';fnames[5]='NOTES';ftypes[5]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
+<script type="text/javascript" src="//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js"></script><script type="text/javascript">(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';fnames[6]='COUNTRY';ftypes[6]='text';fnames[3]='RESEARCH';ftypes[3]='dropdown';fnames[4]='CLASS';ftypes[4]='text';fnames[5]='NOTES';ftypes[5]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script></div>

--- a/source/help/faq/aaclass.md
+++ b/source/help/faq/aaclass.md
@@ -11,8 +11,8 @@ aa.cls file. This looks like:
   
 ```
 
-For additional information please consult the [A\&A
-website](http://www.aanda.org/author-information/latex-issues/texnical-background-information).
+For additional information please consult the [A&A
+website](https://www.aanda.org/for-authors/latex-issues/texnical-background-information).
 
 arXiv used **aa.cls version 6.1** `[2006/06/01 v6.1 LaTeX document class
 for Astronomy and Astrophysics journal]` for new submissions and


### PR DESCRIPTION
Merging approved updates to production.
Removed `\` in link text. 
Linked the text to a working pathway.