### PR TITLE
ARXIVCE-3349: remove the tableau graphs, now that our license has exp…

### DIFF
--- a/source/about/reports/2020_institution_downloads.md
+++ b/source/about/reports/2020_institution_downloads.md
@@ -6,17 +6,7 @@ The following table shows the institutions with the most downloads in 2020. To s
 
 **Note**: Please see caveats related to usage data on [arXiv in Numbers](2020_usage.md)
 
-
-<script type='text/javascript' src='https://tableau.cornell.edu/javascripts/api/viz_v1.js'></script>
-<div class='tableauPlaceholder' style='width: 742px; height: 599px; border: 1px solid gray;'>
-  <object class='tableauViz' width='742' height='599' style='display:none;'>
-  <param name='host_url' value='https%3A%2F%2Ftableau.cornell.edu%2F' />
-  <param name='embed_code_version' value='3' />
-  <param name='site_root' value='&#47;t&#47;PublicContent' />
-  <param name='name' value='arXiv2020byInstitution&#47;arXiv2020ByInstitution' />
-  <param name='tabs' value='no' />
-  <param name='toolbar' value='yes' />
-  <param name='showAppBanner' value='false' />
-  </object>
-</div>
-
+<p>
+<img src="https://arxiv.org/icons/skulls/skull1.gif"/>
+Please bear with us as we upgrade our graphs. We anticipate their return in Fall 2025.
+</p>

--- a/source/about/reports/2020_institution_downloads_by_archive.md
+++ b/source/about/reports/2020_institution_downloads_by_archive.md
@@ -6,15 +6,8 @@ The following table shows institutions' downloads across [subject archives](http
 
 **Note**: Please see caveats related to usage data on [arXiv in Numbers](2020_usage.md)
 
-<script type='text/javascript' src='https://tableau.cornell.edu/javascripts/api/viz_v1.js'></script>
-<div class='tableauPlaceholder' style='width: 742px; height: 599px; border: 1px solid gray;'>
-  <object class='tableauViz' width='742' height='599' style='display:none;'>
-  <param name='host_url' value='https%3A%2F%2Ftableau.cornell.edu%2F' />
-  <param name='embed_code_version' value='3' />
-  <param name='site_root' value='&#47;t&#47;PublicContent' />
-  <param name='name' value='arXiv2020byInstitutionArchive&#47;Sheet1' />
-  <param name='tabs' value='no' />
-  <param name='toolbar' value='yes' />
-  <param name='showAppBanner' value='false' />
-  </object>
-</div>
+<p>
+<img src="https://arxiv.org/icons/image2.gif"/>
+Please bear with us as we upgrade our graphs. We anticipate their return in Fall 2025.
+</p>
+

--- a/source/about/reports/2020_institution_downloads_by_year.md
+++ b/source/about/reports/2020_institution_downloads_by_year.md
@@ -6,15 +6,8 @@ Select the domain of interest by checking the appropriate box. The resulting tab
 
 **Note**: Please see caveats related to usage data on [arXiv in Numbers](2020_usage.md)
 
-<script type='text/javascript' src='https://tableau.cornell.edu/javascripts/api/viz_v1.js'></script>
-<div class='tableauPlaceholder' style='width: 742px; height: 599px; border: 1px solid gray;'>
-  <object class='tableauViz' width='742' height='599' style='display:none;'>
-  <param name='host_url' value='https%3A%2F%2Ftableau.cornell.edu%2F' />
-  <param name='embed_code_version' value='3' />
-  <param name='site_root' value='&#47;t&#47;PublicContent' />
-  <param name='name' value='arXivInstUsage&#47;InstitutionByYear2' />
-  <param name='tabs' value='no' />
-  <param name='toolbar' value='yes' />
-  <param name='showAppBanner' value='false' />
-  </object>
-</div>
+<p>
+<img src="https://arxiv.org/icons/image3.gif"/>
+Please bear with us as we upgrade our graphs. We anticipate their return in Fall 2025.
+</p>
+

--- a/source/about/reports/2020_institution_submissions.md
+++ b/source/about/reports/2020_institution_submissions.md
@@ -6,15 +6,8 @@ The following table shows submissions by institution in 2018, 2019, and 2020. To
 
 **Note**: This data for submissions by institution was provided by [Microsoft Academics](https://academic.microsoft.com/home). Please see caveats related to usage data on [arXiv in Numbers](2020_usage.md)
 
-<script type='text/javascript' src='https://tableau.cornell.edu/javascripts/api/viz_v1.js'></script>
-<div class='tableauPlaceholder' style='width: 742px; height: 599px;'>
-  <object class='tableauViz' width='742' height='599' style='display:none;'>
-  <param name='host_url' value='https%3A%2F%2Ftableau.cornell.edu%2F' />
-  <param name='embed_code_version' value='3' />
-  <param name='site_root' value='&#47;t&#47;PublicContent' />
-  <param name='name' value='arXivPapersByInst&#47;Sheet1' />
-  <param name='tabs' value='no' />
-  <param name='toolbar' value='yes' />
-  <param name='showAppBanner' value='false' />
-  </object>
-</div>
+<p>
+<img src="https://arxiv.org/icons/world1.gif"/>
+Please bear with us as we upgrade our graphs. We anticipate their return in Fall 2025.
+</p>
+

--- a/source/about/reports/2021_institution_submissions.md
+++ b/source/about/reports/2021_institution_submissions.md
@@ -6,19 +6,8 @@ Submissions by Institution will be made available to members only by June 2022.
 
 The following table shows submissions by institution in 2019, 2020, and 2021. To search for a specific institution, hover your mouse over the right hand corner of the list of institutions to reveal the search icon. [To learn how this information is used in the membership program, see here](../../about/membership.md).
 
+<p>
+<img src="https://arxiv.org/icons/sfx.gif"/>
+Please bear with us as we upgrade our graphs. We anticipate their return in Fall 2025.
+</p>
 
-<script type='text/javascript' src='https://tableau.cornell.edu/javascripts/api/viz_v1.js'></script>
-<div class='tableauPlaceholder' style='width: 842px; height: 599px;'>
-  <object class='tableauViz' width='842' height='599' style='display:none;'>
-  <param name='host_url' value='https%3A%2F%2Ftableau.cornell.edu%2F' />
-  <param name='embed_code_version' value='3' />
-  <param name='site_root' value='&#47;t&#47;PublicContent' />
-  <param name='name' value='submissions22&#47;AverageAnnualSubmissions2019-2021' />
-  <param name='tabs' value='no' />
-  <param name='toolbar' value='yes' />
-  <param name='showAppBanner' value='false' />
-  </object>
-</div>
-
-Data provided by
-<img width="44" style="vertical-align:middle" src='https://arxiv.org/scopus.png'/>

--- a/source/about/reports/2022_institution_submissions.md
+++ b/source/about/reports/2022_institution_submissions.md
@@ -10,19 +10,8 @@ Submissions by Institution will be made available to members only by June 2023.
 
 The following table shows submissions by institution in 2020, 2021, and 2022. To search for a specific institution, hover your mouse over the right hand corner of the list of institutions to reveal the search icon. [To learn how this information is used in the membership program, see here](../../about/membership.md).
 
+<p>
+<img src="https://arxiv.org/icons/world1.gif"/>
+Please bear with us as we upgrade our graphs. We anticipate their return in Fall 2025.
+</p>
 
-<script type='text/javascript' src='https://tableau.cornell.edu/javascripts/api/viz_v1.js'></script>
-<div class='tableauPlaceholder' style='width: 842px; height: 599px;'>
-  <object class='tableauViz' width='842' height='599' style='display:none;'>
-  <param name='host_url' value='https%3A%2F%2Ftableau.cornell.edu%2F' />
-  <param name='embed_code_version' value='3' />
-  <param name='site_root' value='&#47;t&#47;PublicContent' />
-  <param name='name' value='submissions2023&#47;AverageAnnualSubmissions2020-2022' />
-  <param name='tabs' value='no' />
-  <param name='toolbar' value='yes' />
-  <param name='showAppBanner' value='false' />
-  </object>
-</div>
-
-Data provided by
-<img width="44" style="vertical-align:middle" src='https://arxiv.org/scopus.png'/>

--- a/source/about/reports/submission_category_by_year.md
+++ b/source/about/reports/submission_category_by_year.md
@@ -4,15 +4,8 @@ See more [arXiv reports](index.md) and [Usage stats](https://arxiv.org/stats/mai
 
 The following tables show submissions to arXiv by [category](https://arxiv.org/category_taxonomy). Explore different views of the data by toggling between sheets.
 
-<script type='text/javascript' src='https://tableau.cornell.edu/javascripts/api/viz_v1.js'></script>
-<div class='tableauPlaceholder' style='width: 842px; height: 630px; border: 1px solid gray;'>
-  <object class='tableauViz' width='842' height='630' style='display:none;'>
-  <param name='host_url' value='https%3A%2F%2Ftableau.cornell.edu%2F' />
-  <param name='embed_code_version' value='3' />
-  <param name='site_root' value='&#47;t&#47;PublicContent' />
-  <param name='name' value='arXivSubmissions&#47;LineGraphByArchive' />
-  <param name='tabs' value='yes' />
-  <param name='toolbar' value='yes' />
-  <param name='showAppBanner' value='false' />
-  </object>
-</div>
+<p>
+<img src="https://arxiv.org/icons/graphs.gif"/>
+Please bear with us as we upgrade our graphs. We anticipate their return in Fall 2025.
+</p>
+


### PR DESCRIPTION
…ired.

This removes the tableau graphs on our report pages, and replaces it with a maintenance messages.

arXiv has some funky old icons.

Preview:
- https://storage.googleapis.com/arxiv-docs-prs/ARXIVCE-3349-remove-tableau/about/reports/2020_institution_downloads_by_archive.html
- https://storage.googleapis.com/arxiv-docs-prs/ARXIVCE-3349-remove-tableau/about/reports/2020_institution_downloads_by_year.html
- https://storage.googleapis.com/arxiv-docs-prs/ARXIVCE-3349-remove-tableau/about/reports/2020_institution_downloads.html
- https://storage.googleapis.com/arxiv-docs-prs/ARXIVCE-3349-remove-tableau/about/reports/2020_institution_submissions.html
- https://storage.googleapis.com/arxiv-docs-prs/ARXIVCE-3349-remove-tableau/about/reports/2021_institution_submissions.html
- https://storage.googleapis.com/arxiv-docs-prs/ARXIVCE-3349-remove-tableau/about/reports/2022_institution_submissions.html
- https://storage.googleapis.com/arxiv-docs-prs/ARXIVCE-3349-remove-tableau/about/reports/submission_category_by_year.html
