### PR TITLE
[ARXIVCE-3826] Replace 'submissions by institution' tableau with datatables

### DIFF
--- a/source/about/reports/2020_institution_submissions.md
+++ b/source/about/reports/2020_institution_submissions.md
@@ -119,7 +119,7 @@ The following table shows submissions by institution in 2018, 2019, and 2020. [T
 </div>
 
 
-<script type='text/javascript' src="2020_institution_submissions.js"></script>
+<script type='text/javascript' src="https://storage.googleapis.com/info-arxiv-org-stats/2020_institution_submissions.js"></script>
 
 Data provided by
 <img width="44" style="vertical-align:middle" src='https://arxiv.org/scopus.png'/>

--- a/source/about/reports/2020_institution_submissions.md
+++ b/source/about/reports/2020_institution_submissions.md
@@ -1,20 +1,125 @@
-# Submissions by Institution
+<script type='text/javascript' src="https://code.jquery.com/jquery-3.7.1.js"></script>  
+<script type='text/javascript' src="https://cdn.datatables.net/2.1.2/js/dataTables.js"></script>  
+<link href="https://cdn.datatables.net/2.1.2/css/dataTables.dataTables.css" rel="stylesheet" type="text/css"> 
+
+# Submissions by Institution (2020)
 
 _See more [arXiv in Numbers](2020_usage.md)_
 
-The following table shows submissions by institution in 2018, 2019, and 2020. To search for a specific institution, hover your mouse over the right hand corner of the list of institutions to reveal the search icon. [To learn how this information is used in the membership program, see here](../../about/membership.md).
+The following table shows submissions by institution in 2018, 2019, and 2020. [To learn how this information is used in the membership program, see here](../../about/membership.md).
 
-**Note**: This data for submissions by institution was provided by [Microsoft Academics](https://academic.microsoft.com/home). Please see caveats related to usage data on [arXiv in Numbers](2020_usage.md)
 
-<script type='text/javascript' src='https://tableau.cornell.edu/javascripts/api/viz_v1.js'></script>
-<div class='tableauPlaceholder' style='width: 742px; height: 599px;'>
-  <object class='tableauViz' width='742' height='599' style='display:none;'>
-  <param name='host_url' value='https%3A%2F%2Ftableau.cornell.edu%2F' />
-  <param name='embed_code_version' value='3' />
-  <param name='site_root' value='&#47;t&#47;PublicContent' />
-  <param name='name' value='arXivPapersByInst&#47;Sheet1' />
-  <param name='tabs' value='no' />
-  <param name='toolbar' value='yes' />
-  <param name='showAppBanner' value='false' />
-  </object>
+
+<style>
+
+    .filters-wrapper {
+        display: flex;
+        justify-content: space-between;
+        margin-bottom: 20px;
+        width: 100%;
+    }
+
+    .filter-item {
+        box-sizing: border-box;
+    }
+
+    .filter-item:first-child {
+        width: calc(65% - 20px);
+    }
+
+    .filter-item:last-child {
+        width: 35%;
+    }
+
+.filters-container {
+    height: 200px;
+    overflow-y: auto;
+    border: 1px solid #ccc;
+    padding: 10px;
+    font-size: .9em;
+}
+
+    #institution_rank_wrapper {
+        width: 100%;
+    }
+
+    .dataTables_wrapper {
+        width: 100%;
+    }
+
+    .dataTables_filter {
+        width: 30%;
+        float: right;
+    }
+
+    table.dataTable {
+        width: 100% !important;
+        font-size: .9em; 
+    }
+
+    table.dataTable thead th {
+        white-space: nowrap;
+    }
+
+    #institution-filter br,
+    #country-filter br {
+        display: none;
+    }
+
+    #institution-filter label,
+    #country-filter label {
+        display: flex;
+        align-items: flex-start;
+        margin-bottom: 5px;
+        line-height: 1.2;
+    }
+
+    #institution-filter input[type="checkbox"],
+    #country-filter input[type="checkbox"] {
+        margin-right: 5px;
+        margin-top: 2px;
+    }
+
+    #institution-filter label span,
+    #country-filter label span {
+        display: inline-block;
+        padding-left: 20px;
+        text-indent: -20px;
+    }
+
+    .filter-item input[type="text"] {
+        width: 100%;
+        padding: 5px;
+        margin-bottom: 10px;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        box-sizing: border-box;
+    }
+</style>
+
+<div class="filters-wrapper">
+    <div class="filter-item">
+        <h4 style="margin-bottom: 0px;">Institution Name</h4>
+        <input type="text" id="institution-search" placeholder="Search institutions...">
+        <div class="filters-container" id="institution-filter-container">
+            <div id="institution-filter"></div>
+        </div>
+    </div>
+    <div class="filter-item">
+        <h4 style="margin-bottom: 0px;">Country</h4>
+        <input type="text" id="country-search" placeholder="Search countries...">
+        <div class="filters-container" id="country-filter-container">
+            <div id="country-filter"></div>
+        </div>
+    </div>
 </div>
+
+<div id="institution_rank_wrapper">
+    <table id="institution_rank" class="display compact"></table>
+</div>
+
+
+<script type='text/javascript' src="2020_institution_submissions.js"></script>
+
+Data provided by
+<img width="44" style="vertical-align:middle" src='https://arxiv.org/scopus.png'/>

--- a/source/about/reports/2020_institution_submissions.md
+++ b/source/about/reports/2020_institution_submissions.md
@@ -105,13 +105,13 @@ The following table shows submissions by institution in 2018, 2019, and 2020. [T
             <div id="institution-filter"></div>
         </div>
     </div>
-    <div class="filter-item">
+    <!-- <div class="filter-item">
         <h4 style="margin-bottom: 0px;">Country</h4>
         <input type="text" id="country-search" placeholder="Search countries...">
         <div class="filters-container" id="country-filter-container">
             <div id="country-filter"></div>
         </div>
-    </div>
+    </div> -->
 </div>
 
 <div id="institution_rank_wrapper">
@@ -119,7 +119,7 @@ The following table shows submissions by institution in 2018, 2019, and 2020. [T
 </div>
 
 
-<script type='text/javascript' src="https://storage.googleapis.com/info-arxiv-org-stats/2020_institution_submissions.js"></script>
+<script type='text/javascript' src="2020_institution_submissions.js"></script>
 
 Data provided by
 <img width="44" style="vertical-align:middle" src='https://arxiv.org/scopus.png'/>

--- a/source/about/reports/2020_institution_submissions.md
+++ b/source/about/reports/2020_institution_submissions.md
@@ -105,13 +105,6 @@ The following table shows submissions by institution in 2018, 2019, and 2020. [T
             <div id="institution-filter"></div>
         </div>
     </div>
-    <!-- <div class="filter-item">
-        <h4 style="margin-bottom: 0px;">Country</h4>
-        <input type="text" id="country-search" placeholder="Search countries...">
-        <div class="filters-container" id="country-filter-container">
-            <div id="country-filter"></div>
-        </div>
-    </div> -->
 </div>
 
 <div id="institution_rank_wrapper">
@@ -119,7 +112,7 @@ The following table shows submissions by institution in 2018, 2019, and 2020. [T
 </div>
 
 
-<script type='text/javascript' src="2020_institution_submissions.js"></script>
+<script type='text/javascript' src="https://storage.googleapis.com/info-arxiv-org-stats/2020_institution_submissions.js"></script>
 
 Data provided by
 <img width="44" style="vertical-align:middle" src='https://arxiv.org/scopus.png'/>

--- a/source/about/reports/2021_institution_submissions.md
+++ b/source/about/reports/2021_institution_submissions.md
@@ -1,3 +1,7 @@
+<script type='text/javascript' src="https://code.jquery.com/jquery-3.7.1.js"></script>  
+<script type='text/javascript' src="https://cdn.datatables.net/2.1.2/js/dataTables.js"></script>  
+<link href="https://cdn.datatables.net/2.1.2/css/dataTables.dataTables.css" rel="stylesheet" type="text/css"> 
+
 # Submissions by Institution (2021)
 
 _See more [arXiv in Numbers](2021_usage.md)_
@@ -7,18 +11,117 @@ Submissions by Institution will be made available to members only by June 2022.
 The following table shows submissions by institution in 2019, 2020, and 2021. To search for a specific institution, hover your mouse over the right hand corner of the list of institutions to reveal the search icon. [To learn how this information is used in the membership program, see here](../../about/membership.md).
 
 
-<script type='text/javascript' src='https://tableau.cornell.edu/javascripts/api/viz_v1.js'></script>
-<div class='tableauPlaceholder' style='width: 842px; height: 599px;'>
-  <object class='tableauViz' width='842' height='599' style='display:none;'>
-  <param name='host_url' value='https%3A%2F%2Ftableau.cornell.edu%2F' />
-  <param name='embed_code_version' value='3' />
-  <param name='site_root' value='&#47;t&#47;PublicContent' />
-  <param name='name' value='submissions22&#47;AverageAnnualSubmissions2019-2021' />
-  <param name='tabs' value='no' />
-  <param name='toolbar' value='yes' />
-  <param name='showAppBanner' value='false' />
-  </object>
+
+<style>
+
+    .filters-wrapper {
+        display: flex;
+        justify-content: space-between;
+        margin-bottom: 20px;
+        width: 100%;
+    }
+
+    .filter-item {
+        box-sizing: border-box;
+    }
+
+    .filter-item:first-child {
+        width: calc(65% - 20px);
+    }
+
+    .filter-item:last-child {
+        width: 35%;
+    }
+
+.filters-container {
+    height: 200px;
+    overflow-y: auto;
+    border: 1px solid #ccc;
+    padding: 10px;
+    font-size: .9em;
+}
+
+    #institution_rank_wrapper {
+        width: 100%;
+    }
+
+    .dataTables_wrapper {
+        width: 100%;
+    }
+
+    .dataTables_filter {
+        width: 30%;
+        float: right;
+    }
+
+    table.dataTable {
+        width: 100% !important;
+        font-size: .9em; 
+    }
+
+    table.dataTable thead th {
+        white-space: nowrap;
+    }
+
+    #institution-filter br,
+    #country-filter br {
+        display: none;
+    }
+
+    #institution-filter label,
+    #country-filter label {
+        display: flex;
+        align-items: flex-start;
+        margin-bottom: 5px;
+        line-height: 1.2;
+    }
+
+    #institution-filter input[type="checkbox"],
+    #country-filter input[type="checkbox"] {
+        margin-right: 5px;
+        margin-top: 2px;
+    }
+
+    #institution-filter label span,
+    #country-filter label span {
+        display: inline-block;
+        padding-left: 20px;
+        text-indent: -20px;
+    }
+
+    .filter-item input[type="text"] {
+        width: 100%;
+        padding: 5px;
+        margin-bottom: 10px;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        box-sizing: border-box;
+    }
+</style>
+
+<div class="filters-wrapper">
+    <div class="filter-item">
+        <h4 style="margin-bottom: 0px;">Institution Name</h4>
+        <input type="text" id="institution-search" placeholder="Search institutions...">
+        <div class="filters-container" id="institution-filter-container">
+            <div id="institution-filter"></div>
+        </div>
+    </div>
+    <div class="filter-item">
+        <h4 style="margin-bottom: 0px;">Country</h4>
+        <input type="text" id="country-search" placeholder="Search countries...">
+        <div class="filters-container" id="country-filter-container">
+            <div id="country-filter"></div>
+        </div>
+    </div>
 </div>
+
+<div id="institution_rank_wrapper">
+    <table id="institution_rank" class="display compact"></table>
+</div>
+
+
+<script type='text/javascript' src="https://storage.googleapis.com/info-arxiv-org-stats/2021_institution_submissions.js"></script>
 
 Data provided by
 <img width="44" style="vertical-align:middle" src='https://arxiv.org/scopus.png'/>

--- a/source/about/reports/2021_institution_submissions.md
+++ b/source/about/reports/2021_institution_submissions.md
@@ -6,9 +6,7 @@
 
 _See more [arXiv in Numbers](2021_usage.md)_
 
-Submissions by Institution will be made available to members only by June 2022.
-
-The following table shows submissions by institution in 2019, 2020, and 2021. To search for a specific institution, hover your mouse over the right hand corner of the list of institutions to reveal the search icon. [To learn how this information is used in the membership program, see here](../../about/membership.md).
+The following table shows submissions by institution in 2019, 2020, and 2021. [To learn how this information is used in the membership program, see here](../../about/membership.md).
 
 
 

--- a/source/about/reports/2022_institution_submissions.md
+++ b/source/about/reports/2022_institution_submissions.md
@@ -6,7 +6,7 @@
 
 _See more [arXiv in Numbers](2022_usage.md)_
 
-The following table shows submissions by institution in 2020, 2021, and 2022. To search for a specific institution, hover your mouse over the right hand corner of the list of institutions to reveal the search icon. [To learn how this information is used in the membership program, see here](../../about/membership.md).
+The following table shows submissions by institution in 2020, 2021, and 2022. [To learn how this information is used in the membership program, see here](../../about/membership.md).
 
 
 

--- a/source/about/reports/2022_institution_submissions.md
+++ b/source/about/reports/2022_institution_submissions.md
@@ -1,28 +1,125 @@
----
-hide:
-  - toc
----
+<script type='text/javascript' src="https://code.jquery.com/jquery-3.7.1.js"></script>  
+<script type='text/javascript' src="https://cdn.datatables.net/2.1.2/js/dataTables.js"></script>  
+<link href="https://cdn.datatables.net/2.1.2/css/dataTables.dataTables.css" rel="stylesheet" type="text/css"> 
+
 # Submissions by Institution (2022)
 
 _See more [arXiv in Numbers](2022_usage.md)_
 
-Submissions by Institution will be made available to members only by June 2023.
-
 The following table shows submissions by institution in 2020, 2021, and 2022. To search for a specific institution, hover your mouse over the right hand corner of the list of institutions to reveal the search icon. [To learn how this information is used in the membership program, see here](../../about/membership.md).
 
 
-<script type='text/javascript' src='https://tableau.cornell.edu/javascripts/api/viz_v1.js'></script>
-<div class='tableauPlaceholder' style='width: 842px; height: 599px;'>
-  <object class='tableauViz' width='842' height='599' style='display:none;'>
-  <param name='host_url' value='https%3A%2F%2Ftableau.cornell.edu%2F' />
-  <param name='embed_code_version' value='3' />
-  <param name='site_root' value='&#47;t&#47;PublicContent' />
-  <param name='name' value='submissions2023&#47;AverageAnnualSubmissions2020-2022' />
-  <param name='tabs' value='no' />
-  <param name='toolbar' value='yes' />
-  <param name='showAppBanner' value='false' />
-  </object>
+
+<style>
+
+    .filters-wrapper {
+        display: flex;
+        justify-content: space-between;
+        margin-bottom: 20px;
+        width: 100%;
+    }
+
+    .filter-item {
+        box-sizing: border-box;
+    }
+
+    .filter-item:first-child {
+        width: calc(65% - 20px);
+    }
+
+    .filter-item:last-child {
+        width: 35%;
+    }
+
+.filters-container {
+    height: 200px;
+    overflow-y: auto;
+    border: 1px solid #ccc;
+    padding: 10px;
+    font-size: .9em;
+}
+
+    #institution_rank_wrapper {
+        width: 100%;
+    }
+
+    .dataTables_wrapper {
+        width: 100%;
+    }
+
+    .dataTables_filter {
+        width: 30%;
+        float: right;
+    }
+
+    table.dataTable {
+        width: 100% !important;
+        font-size: .9em; 
+    }
+
+    table.dataTable thead th {
+        white-space: nowrap;
+    }
+
+    #institution-filter br,
+    #country-filter br {
+        display: none;
+    }
+
+    #institution-filter label,
+    #country-filter label {
+        display: flex;
+        align-items: flex-start;
+        margin-bottom: 5px;
+        line-height: 1.2;
+    }
+
+    #institution-filter input[type="checkbox"],
+    #country-filter input[type="checkbox"] {
+        margin-right: 5px;
+        margin-top: 2px;
+    }
+
+    #institution-filter label span,
+    #country-filter label span {
+        display: inline-block;
+        padding-left: 20px;
+        text-indent: -20px;
+    }
+
+    .filter-item input[type="text"] {
+        width: 100%;
+        padding: 5px;
+        margin-bottom: 10px;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        box-sizing: border-box;
+    }
+</style>
+
+<div class="filters-wrapper">
+    <div class="filter-item">
+        <h4 style="margin-bottom: 0px;">Institution Name</h4>
+        <input type="text" id="institution-search" placeholder="Search institutions...">
+        <div class="filters-container" id="institution-filter-container">
+            <div id="institution-filter"></div>
+        </div>
+    </div>
+    <div class="filter-item">
+        <h4 style="margin-bottom: 0px;">Country</h4>
+        <input type="text" id="country-search" placeholder="Search countries...">
+        <div class="filters-container" id="country-filter-container">
+            <div id="country-filter"></div>
+        </div>
+    </div>
 </div>
+
+<div id="institution_rank_wrapper">
+    <table id="institution_rank" class="display compact"></table>
+</div>
+
+
+<script type='text/javascript' src="https://storage.googleapis.com/info-arxiv-org-stats/2022_institution_submissions.js"></script>
 
 Data provided by
 <img width="44" style="vertical-align:middle" src='https://arxiv.org/scopus.png'/>


### PR DESCRIPTION
Link to ticket(s):
https://arxiv-org.atlassian.net/browse/ARXIVCE-3349 
https://arxiv-org.atlassian.net/browse/ARXIVCE-3826

### Context
This PR replaces tableau plots at `info.arxiv.org/about/reports/reports/{year}_institution_submissions.html` with jquery datatables in order to remove tableau as a dependency.

https://info.arxiv.org/about/reports/2020_institution_submissions.html
https://info.arxiv.org/about/reports/2021_institution_submissions.html
https://info.arxiv.org/about/reports/2022_institution_submissions.html

Datatables are used for consistency with 2023 and 2024 pages. Data is loaded from .js files added to an existing public-facing bucket in GCP. The data is not sensitive.

The long term goal is to move these into a more centralized 'stats' domain within arXiv, at which point they can be further improved.

### Testing instructions