### PR TITLE
[ARXIVCE-3827] Replace 'downloads by institution' tableau

### DIFF
--- a/source/about/reports/2020_institution_downloads.md
+++ b/source/about/reports/2020_institution_downloads.md
@@ -1,22 +1,120 @@
+---
+hide:
+- toc
+---
+
+<script type='text/javascript' src="https://code.jquery.com/jquery-3.7.1.js"></script>  
+<script type='text/javascript' src="https://cdn.datatables.net/2.1.2/js/dataTables.js"></script>  
+<link href="https://cdn.datatables.net/2.1.2/css/dataTables.dataTables.css" rel="stylesheet" type="text/css"> 
+
 # Downloads by Institution in 2020
 
 _See more [arXiv in Numbers](2020_usage.md)_
 
-The following table shows the institutions with the most downloads in 2020. To search for a specific institutional domain, hover your mouse over the right hand corner of the table to reveal the search icon.
+The following table shows institutions' downloads for 2020. 
 
 **Note**: Please see caveats related to usage data on [arXiv in Numbers](2020_usage.md)
 
+<style>
 
-<script type='text/javascript' src='https://tableau.cornell.edu/javascripts/api/viz_v1.js'></script>
-<div class='tableauPlaceholder' style='width: 742px; height: 599px; border: 1px solid gray;'>
-  <object class='tableauViz' width='742' height='599' style='display:none;'>
-  <param name='host_url' value='https%3A%2F%2Ftableau.cornell.edu%2F' />
-  <param name='embed_code_version' value='3' />
-  <param name='site_root' value='&#47;t&#47;PublicContent' />
-  <param name='name' value='arXiv2020byInstitution&#47;arXiv2020ByInstitution' />
-  <param name='tabs' value='no' />
-  <param name='toolbar' value='yes' />
-  <param name='showAppBanner' value='false' />
-  </object>
+    .filters-wrapper {
+        display: flex;
+        justify-content: space-between;
+        margin-bottom: 20px;
+        width: 100%;
+    }
+
+    .filter-item {
+        box-sizing: border-box;
+    }
+
+    .filter-item:first-child {
+        width: calc(65% - 20px);
+    }
+
+    .filter-item:last-child {
+        width: 35%;
+    }
+
+.filters-container {
+    height: 200px;
+    overflow-y: auto;
+    border: 1px solid #ccc;
+    padding: 10px;
+    font-size: .9em;
+}
+
+    #domain_rank_wrapper {
+        width: 100%;
+    }
+
+    .dataTables_wrapper {
+        width: 100%;
+    }
+
+    .dataTables_filter {
+        width: 30%;
+        float: right;
+    }
+
+    table.dataTable {
+        width: 100% !important;
+        font-size: .9em; 
+    }
+
+    table.dataTable thead th {
+        white-space: nowrap;
+    }
+
+    #domain-filter br,
+    #year-filter br {
+        display: none;
+    }
+
+    #domain-filter label,
+    #year-filter label {
+        display: flex;
+        align-items: flex-start;
+        margin-bottom: 5px;
+        line-height: 1.2;
+    }
+
+    #domain-filter input[type="checkbox"],
+    #year-filter input[type="checkbox"] {
+        margin-right: 5px;
+        margin-top: 2px;
+    }
+
+    #domain-filter label span,
+    #year-filter label span {
+        display: inline-block;
+        padding-left: 20px;
+        text-indent: -20px;
+    }
+
+    .filter-item input[type="text"] {
+        width: 100%;
+        padding: 5px;
+        margin-bottom: 10px;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        box-sizing: border-box;
+    }
+</style>
+
+<div class="filters-wrapper">
+    <div class="filter-item">
+        <h4 style="margin-bottom: 0px;">Domain</h4>
+        <input type="text" id="domain-search" placeholder="Search domains...">
+        <div class="filters-container" id="domain-filter-container">
+            <div id="domain-filter"></div>
+        </div>
+    </div>
 </div>
 
+<div id="domain_rank_wrapper">
+    <table id="domain_rank" class="display compact"></table>
+</div>
+
+
+<script type='text/javascript' src="https://storage.googleapis.com/info-arxiv-org-stats/2020_downloads_by_institution.js"></script>

--- a/source/about/reports/2020_institution_downloads_by_archive.md
+++ b/source/about/reports/2020_institution_downloads_by_archive.md
@@ -1,3 +1,12 @@
+---
+hide:
+- toc
+---
+
+<script type='text/javascript' src="https://code.jquery.com/jquery-3.7.1.js"></script>  
+<script type='text/javascript' src="https://cdn.datatables.net/2.1.2/js/dataTables.js"></script>  
+<link href="https://cdn.datatables.net/2.1.2/css/dataTables.dataTables.css" rel="stylesheet" type="text/css"> 
+
 # Institutional Downloads by Subject Archive in 2020
 
 _See more [arXiv in Numbers](2020_usage.md)_
@@ -6,15 +15,113 @@ The following table shows institutions' downloads across [subject archives](http
 
 **Note**: Please see caveats related to usage data on [arXiv in Numbers](2020_usage.md)
 
-<script type='text/javascript' src='https://tableau.cornell.edu/javascripts/api/viz_v1.js'></script>
-<div class='tableauPlaceholder' style='width: 742px; height: 599px; border: 1px solid gray;'>
-  <object class='tableauViz' width='742' height='599' style='display:none;'>
-  <param name='host_url' value='https%3A%2F%2Ftableau.cornell.edu%2F' />
-  <param name='embed_code_version' value='3' />
-  <param name='site_root' value='&#47;t&#47;PublicContent' />
-  <param name='name' value='arXiv2020byInstitutionArchive&#47;Sheet1' />
-  <param name='tabs' value='no' />
-  <param name='toolbar' value='yes' />
-  <param name='showAppBanner' value='false' />
-  </object>
+<style>
+
+    .filters-wrapper {
+        display: flex;
+        justify-content: space-between;
+        margin-bottom: 20px;
+        width: 100%;
+    }
+
+    .filter-item {
+        box-sizing: border-box;
+    }
+
+    .filter-item:first-child {
+        width: calc(65% - 20px);
+    }
+
+    .filter-item:last-child {
+        width: 35%;
+    }
+
+.filters-container {
+    height: 200px;
+    overflow-y: auto;
+    border: 1px solid #ccc;
+    padding: 10px;
+    font-size: .9em;
+}
+
+    #domain_rank_wrapper {
+        width: 100%;
+    }
+
+    .dataTables_wrapper {
+        width: 100%;
+    }
+
+    .dataTables_filter {
+        width: 30%;
+        float: right;
+    }
+
+    table.dataTable {
+        width: 100% !important;
+        font-size: .9em; 
+    }
+
+    table.dataTable thead th {
+        white-space: nowrap;
+    }
+
+    #domain-filter br,
+    #year-filter br {
+        display: none;
+    }
+
+    #domain-filter label,
+    #year-filter label {
+        display: flex;
+        align-items: flex-start;
+        margin-bottom: 5px;
+        line-height: 1.2;
+    }
+
+    #domain-filter input[type="checkbox"],
+    #year-filter input[type="checkbox"] {
+        margin-right: 5px;
+        margin-top: 2px;
+    }
+
+    #domain-filter label span,
+    #year-filter label span {
+        display: inline-block;
+        padding-left: 20px;
+        text-indent: -20px;
+    }
+
+    .filter-item input[type="text"] {
+        width: 100%;
+        padding: 5px;
+        margin-bottom: 10px;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        box-sizing: border-box;
+    }
+</style>
+
+<div class="filters-wrapper">
+    <div class="filter-item">
+        <h4 style="margin-bottom: 0px;">Domain</h4>
+        <input type="text" id="domain-search" placeholder="Search domains...">
+        <div class="filters-container" id="domain-filter-container">
+            <div id="domain-filter"></div>
+        </div>
+    </div>
+    <div class="filter-item">
+        <h4 style="margin-bottom: 0px;">Year</h4>
+        <input type="text" id="year-search" placeholder="Search years...">
+        <div class="filters-container" id="year-filter-container">
+            <div id="year-filter"></div>
+        </div>
+    </div>
 </div>
+
+<div id="domain_rank_wrapper">
+    <table id="domain_rank" class="display compact"></table>
+</div>
+
+
+<script type='text/javascript' src="downloads_by_category_by_institution.js"></script>

--- a/source/about/reports/2020_institution_downloads_by_archive.md
+++ b/source/about/reports/2020_institution_downloads_by_archive.md
@@ -124,4 +124,4 @@ The following table shows institutions' downloads across [subject archives](http
 </div>
 
 
-<script type='text/javascript' src="downloads_by_category_by_institution.js"></script>
+<script type='text/javascript' src="https://storage.googleapis.com/info-arxiv-org-stats/downloads_by_category_by_institution.js"></script>

--- a/source/about/reports/2020_institution_downloads_by_archive.md
+++ b/source/about/reports/2020_institution_downloads_by_archive.md
@@ -110,13 +110,6 @@ The following table shows institutions' downloads across [subject archives](http
             <div id="domain-filter"></div>
         </div>
     </div>
-    <div class="filter-item">
-        <h4 style="margin-bottom: 0px;">Year</h4>
-        <input type="text" id="year-search" placeholder="Search years...">
-        <div class="filters-container" id="year-filter-container">
-            <div id="year-filter"></div>
-        </div>
-    </div>
 </div>
 
 <div id="domain_rank_wrapper">
@@ -124,4 +117,4 @@ The following table shows institutions' downloads across [subject archives](http
 </div>
 
 
-<script type='text/javascript' src="https://storage.googleapis.com/info-arxiv-org-stats/downloads_by_category_by_institution.js"></script>
+<script type='text/javascript' src="https://storage.googleapis.com/info-arxiv-org-stats/2020_downloads_by_subject.js"></script>

--- a/source/about/reports/2020_institution_downloads_by_year.md
+++ b/source/about/reports/2020_institution_downloads_by_year.md
@@ -1,20 +1,127 @@
+---
+hide:
+- toc
+---
+
+<script type='text/javascript' src="https://code.jquery.com/jquery-3.7.1.js"></script>  
+<script type='text/javascript' src="https://cdn.datatables.net/2.1.2/js/dataTables.js"></script>  
+<link href="https://cdn.datatables.net/2.1.2/css/dataTables.dataTables.css" rel="stylesheet" type="text/css"> 
+
 # Downloads by Institution (2009-2020)
 
 _See more [arXiv in Numbers](2020_usage.md)_
 
-Select the domain of interest by checking the appropriate box. The resulting table will show downloads by institution from 2009 to 2020. To search for a specific institutional domain, hover your mouse over the right hand corner of the table to reveal the search icon.
+The following table shows downloads by institution each year from 2009 to 2020.
 
 **Note**: Please see caveats related to usage data on [arXiv in Numbers](2020_usage.md)
 
-<script type='text/javascript' src='https://tableau.cornell.edu/javascripts/api/viz_v1.js'></script>
-<div class='tableauPlaceholder' style='width: 742px; height: 599px; border: 1px solid gray;'>
-  <object class='tableauViz' width='742' height='599' style='display:none;'>
-  <param name='host_url' value='https%3A%2F%2Ftableau.cornell.edu%2F' />
-  <param name='embed_code_version' value='3' />
-  <param name='site_root' value='&#47;t&#47;PublicContent' />
-  <param name='name' value='arXivInstUsage&#47;InstitutionByYear2' />
-  <param name='tabs' value='no' />
-  <param name='toolbar' value='yes' />
-  <param name='showAppBanner' value='false' />
-  </object>
+<style>
+
+    .filters-wrapper {
+        display: flex;
+        justify-content: space-between;
+        margin-bottom: 20px;
+        width: 100%;
+    }
+
+    .filter-item {
+        box-sizing: border-box;
+    }
+
+    .filter-item:first-child {
+        width: calc(65% - 20px);
+    }
+
+    .filter-item:last-child {
+        width: 35%;
+    }
+
+.filters-container {
+    height: 200px;
+    overflow-y: auto;
+    border: 1px solid #ccc;
+    padding: 10px;
+    font-size: .9em;
+}
+
+    #domain_rank_wrapper {
+        width: 100%;
+    }
+
+    .dataTables_wrapper {
+        width: 100%;
+    }
+
+    .dataTables_filter {
+        width: 30%;
+        float: right;
+    }
+
+    table.dataTable {
+        width: 100% !important;
+        font-size: .9em; 
+    }
+
+    table.dataTable thead th {
+        white-space: nowrap;
+    }
+
+    #domain-filter br,
+    #year-filter br {
+        display: none;
+    }
+
+    #domain-filter label,
+    #year-filter label {
+        display: flex;
+        align-items: flex-start;
+        margin-bottom: 5px;
+        line-height: 1.2;
+    }
+
+    #domain-filter input[type="checkbox"],
+    #year-filter input[type="checkbox"] {
+        margin-right: 5px;
+        margin-top: 2px;
+    }
+
+    #domain-filter label span,
+    #year-filter label span {
+        display: inline-block;
+        padding-left: 20px;
+        text-indent: -20px;
+    }
+
+    .filter-item input[type="text"] {
+        width: 100%;
+        padding: 5px;
+        margin-bottom: 10px;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        box-sizing: border-box;
+    }
+</style>
+
+<div class="filters-wrapper">
+    <div class="filter-item">
+        <h4 style="margin-bottom: 0px;">Domain</h4>
+        <input type="text" id="domain-search" placeholder="Search domains...">
+        <div class="filters-container" id="domain-filter-container">
+            <div id="domain-filter"></div>
+        </div>
+    </div>
+    <div class="filter-item">
+        <h4 style="margin-bottom: 0px;">Year</h4>
+        <input type="text" id="year-search" placeholder="Search years...">
+        <div class="filters-container" id="year-filter-container">
+            <div id="year-filter"></div>
+        </div>
+    </div>
 </div>
+
+<div id="domain_rank_wrapper">
+    <table id="domain_rank" class="display compact"></table>
+</div>
+
+
+<script type='text/javascript' src="https://storage.googleapis.com/info-arxiv-org-stats/2009_2020_downloads_by_year.js"></script>


### PR DESCRIPTION
Link to ticket(s):
https://arxiv-org.atlassian.net/browse/ARXIVCE-3349 
https://arxiv-org.atlassian.net/browse/ARXIVCE-3827

### Context
This PR replaces tableau plots at the following three links with jquery datatables in order to remove tableau as a dependency.

https://info.arxiv.org/about/reports/2020_institution_downloads.html
https://info.arxiv.org/about/reports/2020_institution_downloads_by_archive.html
https://info.arxiv.org/about/reports/2020_institution_downloads_by_year.html

Datatables are used for consistency with 2023 and 2024 pages. Data is loaded from .js files added to an existing public-facing bucket in GCP. The data is not sensitive.

The long term goal is to move these into a more centralized 'stats' domain within arXiv, at which point they can be further improved.

### Testing instructions
https://storage.googleapis.com/arxiv-docs-prs/ARXIVCE-3827-replace-tableau-downloads/about/reports/2020_institution_downloads.html
https://storage.googleapis.com/arxiv-docs-prs/ARXIVCE-3827-replace-tableau-downloads/about/reports/2020_institution_downloads_by_archive.html
https://storage.googleapis.com/arxiv-docs-prs/ARXIVCE-3827-replace-tableau-downloads/about/reports/2020_institution_downloads_by_year.html