### PR TITLE
Adding comms for NIH response

### DIFF
--- a/source/about/NOT-OD-138.md
+++ b/source/about/NOT-OD-138.md
@@ -1,0 +1,49 @@
+# arXiv NIH Request For Information response
+
+*October 06, 2025*
+
+The US government rightly wishes to ensure that articles reporting results of research funded by US
+taxpayers are made freely accessible immediately (notices NOT-OD-25-047 and NOT-OD-25-101). The
+purpose of notice NOT-OD-25-138 is to ensure that article-processing charges (APCs) levied by journal
+publishers for disseminating these are limited, so that “NIH grantees utilize as much of their grant funds
+as possible for research activities.” The simplest way to achieve this would be to require NIH-funded
+authors to share articles as preprints on non-profit preprint servers such as arXiv (computational and
+physical sciences), bioRxiv (biological sciences), and medRxiv (health sciences) before submitting to
+journals (arXiv 2023). Preprint servers provide rapid free public access to research at no cost to authors
+and, therefore, posting articles to them does not require funds from author's grants. Meanwhile, the
+traditional journal process for both print and online content continues to involve protracted review and
+selection processes. In addition, in order to satisfy increasing Open Access mandates, journal
+publishers have developed business models, such as charging article processing charges (APCs) that
+pass the cost of Open Access publishing onto the authors. For selective journals, APCs can reach more
+than $12,000 per article. With the legitimization of the pay-to-publish model has come an explosion of
+predatory and quasi-predatory journals willing to publish almost anything for a fee. APCs at both ends
+of the spectrum constitute a significant financial burden on funders such as NIH.
+
+Preprint servers like arXiv provide a far more rapid and cost-effective mechanism to distribute research
+findings. Born digital, these disseminate thousands of articles online in standard formats each month
+before they are peer reviewed (for arXiv, typically within a day of submission) at a cost per paper of
+roughly $10 to $20, compared to the thousands of dollars that journals frequently charge.
+
+Sharing of preprints was pioneered in physics by arXiv (launched in 1991), which now hosts papers in
+eight disciplines, distributing about 1,000 new submissions per working day, with 3 million views per
+hour. arXiv currently hosts more than 2.7 million articles and has 5 million active monthly users. bioRxiv
+and medRxiv brought the practice to the biological and health sciences in 2013 and 2019, respectively,
+and are now viewed by ~10 million people each month. Preprint sharing is thus now widely accepted in
+the disciplines funded by NIH. In some cases, high impact papers are only hosted on preprint servers
+and not published in traditional journals. There are many examples of this on arXiv, including “[Attention
+Is All You Need](https://arxiv.org/abs/1706.03762),” which introduced the Transformer network architecture, and “[DeepSeek-R1:
+Incentivizing Reasoning Capability in LLMs via Reinforcement Learning](https://arxiv.org/abs/2501.12948),” which introduced the Deep
+Seek reasoning models.
+
+NIH could achieve free public access to the research that it funds and reduce the costs involved simply
+by requiring that NIH-funded authors post preprints. An important additional benefit would be the
+immediate availability of the research without the long delays associated with journal publication
+(typically around one year). An NIH preprint requirement would underscore the fundamental points that
+the public should have access to the results of research that is publicly funded and that evaluation of
+research is an ongoing process that takes place subsequently. It would also widen the possibilities for
+evolution within the publishing system and avoid channeling it towards expensive APC-based journal
+models.
+
+#### Reference
+arXiv (April 11, 2023). OSTP memorandum response.
+[https://info.arxiv.org/about/OSTP-04-11-2023.html](https://info.arxiv.org/about/OSTP-04-11-2023.html)


### PR DESCRIPTION
Created a new [info.arxiv.org](http://info.arxiv.org/) page in the About section. This page will address arXiv's response to the NIH's RFI.

**Context**
This issue pertains to the need for a dedicated page that informs users about arXiv's response to the NIH's RFI.

**Acceptance criteria**
A new page must be created in the About section of [info.arxiv.org](http://info.arxiv.org/).

The URL should include "NOT-OD-25-138".

The format of the new page should be similar to this existing page: https://info.arxiv.org/about/OSTP-04-11-2023.html.

**Other information**
[Link to content to be used on the new page](https://drive.google.com/file/d/1hkF4SM8g3bNUpiP73Sekr1yCX26Xe-uc/view).