### PR TITLE
3888-arXiv Labs Hiatus Officially going live

### DIFF
--- a/source/labs/index.md
+++ b/source/labs/index.md
@@ -1,6 +1,6 @@
 # arXiv Labs
 
-<a class="button-large" href="#arXiv-Labs-Hiatus">Attention arXiv Users: arXiv Labs is pausing new proposals</a>
+<a class="button-large" href="#arxiv-labs-hiatus">Attention arXiv Users: arXiv Labs is pausing new proposals</a>
 
 ![arXiv Labs icon](images/smileybones-labs-icon.png){.mkd-img-thumb align=right alt='a bubbling beaker with a smiling face and crossedbones behind it' role=presentation}
 


### PR DESCRIPTION
updated the arXiv Labs page to remove links to submit a proposal, added a note stating we are going on hiatus with a link to the blog post. 