### PR TITLE
fix: typo in UC Berkeley's name

### DIFF
--- a/source/about/ourmembers.md
+++ b/source/about/ourmembers.md
@@ -37,7 +37,7 @@ Champion members with arXiv are institutions whose researchers are top users of 
 1. Purdue University (USA) _BTAA_
 1. Penn State University (USA) _BTAA_
 1. University College London (UK) _Jisc_
-1. University of California, Berkleley (USA) _CDL_
+1. University of California, Berkeley (USA) _CDL_
 1. University of Chicago (USA) _BTAA_
 1. University of Illinois - Urbana Champain (USA) _BTAA_
 1. University of Maryland, College Park (USA) _BTAA_


### PR DESCRIPTION
There is a typo in the name "University of California, Berkeley" which I have fixed.