### PR TITLE
Fix accessibility issues from WCAG 2.2 audit

### DIFF
--- a/source/help/withdraw.md
+++ b/source/help/withdraw.md
@@ -43,17 +43,18 @@ Example Withdrawal
 
 The withdrawn version
 
-- As shown in the example below, the withdrawal has created a new version (version 2). 
-- The new withdrawn v2 becomes the default view of the paper. 
-- The reason for the withdrawal is displayed in the Comments field. 
+- The withdrawal creates a new version (version 2) which becomes the default view of the paper.
+- The page will state that the paper has been withdrawn, and by whom.
+- The reason for the withdrawal is displayed in the Comments field.
 - Under the Download options on the right there is no option to download the PDF or TeX.
 
-![withdarawal version 2](Withdraw-sample-v2-2023-05-15.png "withdarawal version 2")
+![Screenshot of a withdrawn paper showing version 2 as the default view. The page displays "This paper has been withdrawn" with the withdrawal reason in the Comments field. The Download section shows no PDF or source options available.](Withdraw-sample-v2-2023-05-15.png "Withdrawn paper - version 2 view")
 
 Previous versions remain accessible.
 
-- All previous versions are still accessible through the links below the Submission History as shown in the example below.
-- A notification that the new version is withdrawn is displayed.
-- The full text can be accessed under the Download options.
+- All previous versions are still accessible through the version links in the Submission History section.
+- The submission history will state "(withdrawn)" alongside the new version of the paper.
+- A notification banner indicates that a newer version has been withdrawn.
+- The full text of previous versions can still be accessed under the Download options.
 
-![withdarawal version 1](Withdraw-sample-v1-2023-05-15.png "withdarawal version 1")
+![Screenshot of version 1 of a withdrawn paper. The page shows a banner stating "The current version of this paper has been withdrawn". The Submission History section shows links to both v1 and v2, with v2 marked as withdrawn. Download options for PDF and source are available for this earlier version.](Withdraw-sample-v1-2023-05-15.png "Withdrawn paper - previous version view")

--- a/source/stylesheets/extra.css
+++ b/source/stylesheets/extra.css
@@ -10,7 +10,7 @@
   --color-open-blue-darker: #787CDD;
   --color-cool-wash:    #f7fafc;
   --color-access-lime:  #c4d82e;
-  --color-links:        #1e8bc3;
+  --color-links:        #1565c0;
   /*fonts*/
   --md-text-font: "freight-sans-pro";
   --md-code-font-family: "ibm-plex-mono", monospace;
@@ -37,6 +37,7 @@
   --md-hue: 35;
   --md-default-bg-color:  hsla(var(--md-hue),10%,10%,1);
   --md-typeset-color:     var(--color-warm-wash);
+  --md-typeset-a-color:   #64b5f6;
   --md-accent-fg-color:   var(--color-open-blue);
   --md-accent-bg-color:   hsla(var(--md-hue),10%,7%,1);
   --md-code-fg-color:     var(--md-primary-fg-color--lightest);
@@ -68,13 +69,20 @@ p {
   font-family: freight-sans-pro, sans-serif;
   font-style: normal;
 }
-a { transition: all 1s ease-in-out; }
+a { transition: all 0.15s ease-in-out; }
 a:hover, a:focus {
   outline-color: var(--md-accent-fg-color);
   outline-offset: 2px;
 }
-.md-content a { text-decoration: underline; }
-.md-content a:hover, .md-content a:focus { text-decoration: none; }
+.md-content a {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  text-decoration-thickness: 1px;
+}
+.md-content a:hover, .md-content a:focus {
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+}
 a:hover { transition: all 0.5s;}
 .md-typeset hr { margin: 1em 0 !important; }
 h1, h2, h3, h4, h5 {
@@ -372,7 +380,7 @@ nav.md-nav.md-nav--primary .md-nav__list .md-nav__item nav.md-nav .md-nav__list 
 }
 pre .md-clipboard {
   color: var(--md-code-fg-color);
-  opacity: 0.3;
+  opacity: 0.5; /* Increased from 0.3 for WCAG 1.4.11 non-text contrast (3:1) */
 }
 /*Blockquotes*/
 .md-typeset blockquote {


### PR DESCRIPTION
Addresses accessibility issues identified in the WCAG 2.2 audit that relate to this repo. All code changes done by Claude. Manually tested locally with accessibility checking tools and VoiceOver when needed.

Audit reports: [Public report](https://docs.google.com/spreadsheets/d/1_NvzUNhq_p8vnyI9bMcdQ6FLksW9W80q2RVhRYQ6wnw/edit?gid=0#gid=0), [Limited access review](https://wa-reviews.hosting.cornell.edu/project/80?tab=issues)

- Update link color to `#1565c0` (light mode) and `#64b5f6` (dark mode) for WCAG AA/AAA contrast compliance. Implements latest design guide work.
- Ensure link underlines are visible with proper offset and thickness
- Increase code copy icon opacity from 0.3 to 0.5 for 3:1 non-text contrast
- Add descriptive alt text to withdrawal page screenshots
- Add aria-labels on empty labels

A few accessibility remediations were not possible due to limitations of the Material theme. The docs site uses form elements in non-standard ways that are throwing errors. But the alternatives I tested out (with Claude doing the code work) felt brittle, and either did not fix the accessibility issue or broke the layout. So these issues persist: 
- Dark mode does not toggle with keyboard navigation (still only triggered by click)
- Accessibility errors for "multiple form labels", related to the dark mode toggle and the search bar