### PR TITLE
fix: malformed span tag

### DIFF
--- a/source/help/submit/index.md
+++ b/source/help/submit/index.md
@@ -96,7 +96,8 @@ See [separate instructions for preparing the title and abstract](../prep.md) for
 abstract pages, in announcements, in RSS feeds, and to support
 searching.
 
-span id="upload"></span>
+<span id="upload"></span>
+
 ## Upload and prepare your submission file
 
 To submit an article, select the "START NEW SUBMISSION" button from your [user page](https://arxiv.org/user).


### PR DESCRIPTION
Hello,

There's a malformed `span` tag on the Submission Guidelines page that hasn't been opened properly. This means it appears as text on the page, as you can see in the screenshot below. It's just above [this subheading](https://info.arxiv.org/help/submit/index.html#upload-and-prepare-your-submission-file) on the main docs.

![screenshot showing issue](https://github.com/user-attachments/assets/62396b14-f98d-4a9c-9d21-a70284c5c20b)

This PR fixes the tag.