### PR TITLE
Restore 'edit this page' pencil on info.arxiv.org

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ hooks:
 theme:
   name: material
   features:
+    - content.action.edit
     - content.tooltips
     - navigation.path
     - navigation.indexes


### PR DESCRIPTION
Jira: [ARXIVCE-4434](https://arxiv-org.atlassian.net/browse/ARXIVCE-4434)

## Symptom
The per-page **edit pencil** that links each info.arxiv.org docs page to its source on GitHub stopped appearing.

## Root cause
The edit pencil is rendered by **mkdocs-material's core content template**. As of **mkdocs-material 9.0**, it is opt-in via the `content.action.edit` theme feature; before 9.0 it rendered automatically whenever `edit_uri` was set. The `content.action.edit` flag has **never** been present in `mkdocs.yml`, while `repo_url`/`edit_uri` have always been set.

## Isolating change
Commit `29bfa5bf` ("Upgrade mkdocs-material to 9.7.6 and enrich a11y via build hook", 2026-04-20) bumped mkdocs-material **8.5.6 → 9.7.6**. The site ran on 8.5.6 from 2023-02-10 until that commit, during which the pencil worked automatically. The 9.x upgrade is the regression point.

This is in **arxiv-docs** only — not arxiv-base. The deployed `overrides/main.html` overrides only `extrahead`/`header`/`footer` and does not touch the content block; arxiv-base supplies the header/footer/head only.

## Fix
Add `- content.action.edit` to `theme.features` in `mkdocs.yml`. `repo_url` (`https://github.com/arXiv/arxiv-docs`) and `edit_uri` (`blob/develop/source`) are already correct, so this one line is sufficient.

## Verification
Once the PR preview build deploys, confirm the pencil appears in a docs page header (e.g. `/about/governance/index.html`) and links to the corresponding `blob/develop/source/...` path on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[ARXIVCE-4434]: https://arxiv-org.atlassian.net/browse/ARXIVCE-4434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ