### PR TITLE
[ARXIVCE-4426] spinout header/footer first feedback

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -161,7 +161,6 @@
       var bar = document.querySelector('.ds-site-header');
       var md = document.querySelector('.md-header[data-md-component="header"]');
       if (!bar || !md) return;
-      var nav = bar.querySelector('.ds-site-header-nav') || bar;
       var brand = bar.querySelector('.ds-site-header-brand');
       // Our .ds-site-header ALSO carries material's `md-header` class, so material's
       // own .md-header search CSS keeps drawing the input + full-width results panel
@@ -169,14 +168,25 @@
       // its behaviour is unchanged — no custom panel CSS.
       var search = md.querySelector('.md-search');
       if (search && brand) brand.insertAdjacentElement('afterend', search);
-      // Color-theme toggle is small — it sits on the right with the nav.
+      // Group the docs controls — color-theme toggle + the relocated search-toggle —
+      // into one cluster appended to the END of the bar (after the nav), so on desktop
+      // they sit at the far right exactly as before. Order within the cluster: theme
+      // toggle, then the magnifying-glass to its right.
+      // Material's mobile search-toggle (the magnifying-glass) lives DIRECTLY in
+      // .md-header — not inside .md-search — so without relocating it, it stays in the
+      // hidden .md-header and mobile users lose the only control that opens the search
+      // overlay. Keeping the cluster OUTSIDE the collapsible nav means both controls
+      // stay visible on mobile (the nav collapses behind the hamburger); a CSS flex
+      // order rule keeps the hamburger itself rightmost there. Material hides the
+      // magnify ≥60em, so on desktop the inline search input remains the search
+      // affordance and only the toggle shows here — no duplicate.
+      var host = document.createElement('div');
+      host.className = 'ds-docs-controls';
       var palette = md.querySelector('[data-md-component="palette"]');
-      if (palette) {
-        var host = document.createElement('div');
-        host.className = 'ds-docs-controls';
-        host.appendChild(palette);
-        nav.appendChild(host);
-      }
+      if (palette) host.appendChild(palette);
+      var searchToggle = md.querySelector('.md-header__button[for="__search"]');
+      if (searchToggle) host.appendChild(searchToggle);
+      bar.appendChild(host);
       document.documentElement.classList.add('ds-docs-unified');
     }
     if (document.readyState !== 'loading') unify();

--- a/source/stylesheets/extra.css
+++ b/source/stylesheets/extra.css
@@ -54,15 +54,6 @@
   --shadow:           black;
 }
 
-/* Spinout chrome parity with arxiv-search. mkdocs-material inflates the root to
-   font-size:125% (→137.5%/150% on wide screens); the .ds-* chrome (and every other
-   surface: search, status, submit) is designed against a 16px base, so the fixed-px
-   header looked vertically thin and the 1200px footer grid looked narrow next to the
-   inflated material content. Resetting to 100% renders info.arxiv.org's chrome at the
-   same scale as arxiv-search — keeping the chrome uniform across repos with no
-   site-specific dimension overrides. */
-html { font-size: 100%; }
-
 body {
   font-family: freight-sans-pro, sans-serif;
   font-style: normal;
@@ -79,7 +70,7 @@ body {
 .ds-site-header-subsite {
   color: var(--arxiv-grey-dis);            /* matches the chrome nav text on the dark bar */
   font-weight: 600;
-  font-size: .95rem;
+  font-size: 14px;                         /* px-pinned like the rest of the chrome (was .95rem → 19px under material's inflated root) */
   line-height: 1;
   padding-left: 10px;
   border-left: 1px solid #4a433d;          /* same hairline as .ds-site-header-divider (untokenized upstream) */
@@ -105,10 +96,26 @@ body {
   flex-shrink: 0;
   margin-left: 8px;
 }
+/* The controls cluster is appended after the nav so it lands at the far right on
+   desktop. On mobile the nav collapses behind the hamburger but the cluster stays
+   visible; the hamburger comes earlier in the DOM, so bump its flex order to keep it
+   rightmost — yielding [theme toggle][search][hamburger]. (≤599px = the chrome's
+   collapsible breakpoint.) */
+@media (max-width: 599px) {
+  .ds-site-header #ds-nav-toggle { order: 10; }
+}
 /* relocated color-theme toggle — light glyphs on the black bar */
 .ds-site-header [data-md-component="palette"] { display: flex; align-items: center; }
 .ds-site-header [data-md-component="palette"] .md-header__button {
   color: var(--arxiv-card-grey);           /* canonical dark-bar control colour (matches .ds-site-header-login) */
+  margin: 0;
+  padding: 6px;
+}
+/* relocated mobile search-toggle (the magnifying-glass) — light glyph on the black
+   bar, matching the other dark-bar controls. Material hides it ≥60em (where the
+   inline input is shown), so this only surfaces on mobile as the overlay trigger. */
+.ds-site-header .md-header__button[for="__search"] {
+  color: var(--arxiv-card-grey);
   margin: 0;
   padding: 6px;
 }
@@ -119,6 +126,34 @@ body {
 .ds-site-header.md-header .md-search { margin-right: auto; }
 .md-header__source {
   display: none !important;
+}
+/* Spinout footer (docs-local override, mirrors arxiv-browse ARXIVCE-4426): span the
+   page width with minimal 10px side margins instead of the shared chrome's centred
+   1200px grid. Scoped via body/descendant so it beats the chrome rule regardless of
+   stylesheet order — docs has no .flex-wrap-footer wrapper to hang it on like browse. */
+body .ds-site-footer { padding-left: 10px; padding-right: 10px; }
+.ds-site-footer .ds-site-footer-grid { max-width: none; }
+
+/* Pin the shared chrome's font-sizes to arxiv-browse's resolved pixels. The chrome
+   declares them in rem against a 16px root (0.875rem→14px, 0.8125rem→13px), but
+   mkdocs-material inflates the root (125%, then 137.5%/150% past 1600/2000px), so the
+   chrome would render ~25–50% larger and drift per breakpoint. The chrome layout is
+   fixed-px, so px here matches browse at every width WITHOUT touching the global root
+   (which would re-shrink all docs content). body-prefixed because the chrome stylesheet
+   loads AFTER extra.css — an equal-specificity override would otherwise lose. */
+body .ds-announcement { font-size: 13px; }
+body .ds-announcement-close { font-size: 14px; }
+body .ds-site-header-nav a,
+body .ds-site-header-nav button { font-size: 13px; }
+body .ds-site-footer-ack { font-size: 14px; }
+body .ds-site-footer-ack a { font-size: 13px; }
+body .ds-site-footer-links { font-size: 13px; }
+body .ds-site-footer-links a { font-size: 13px; }
+body .ds-site-footer-funders-label { font-size: 14px; }
+@media (max-width: 599px) {
+  /* the collapsed mobile nav switches to 0.875rem in the chrome */
+  body .ds-site-header.is-collapsible .ds-site-header-nav a,
+  body .ds-site-header.is-collapsible .ds-site-header-nav button { font-size: 14px; }
 }
 p {
   font-family: freight-sans-pro, sans-serif;

--- a/source/stylesheets/extra.css
+++ b/source/stylesheets/extra.css
@@ -124,6 +124,11 @@ body {
    input and its full-width results panel exactly as upstream — no custom panel CSS.
    The search sits just after the brand and pushes the nav to the right. */
 .ds-site-header.md-header .md-search { margin-right: auto; }
+/* The relocated .md-search lives inside .ds-site-header, which forms a z-index:4
+   stacking context — so its full-screen mobile modal is trapped below the announcement
+   banner (z-index:101). While search is open, lift the header above the banner so the
+   modal covers it instead of rendering behind it. */
+[data-md-toggle="search"]:checked ~ .ds-site-header { z-index: 102; }
 .md-header__source {
   display: none !important;
 }


### PR DESCRIPTION
### Description

- restored search nav menu in mobile
- restored mkdocs sizing 
  - mkdocs-material "zooms" the page by inflating the root font-size to 125%, and 137.5%/150% past 1600/2000px. The shared chrome's sizes are in rem (designed for a 16px root), so under that variable zoom they render ~25–50% too large and change with viewport width. Pinning the chrome to px decouples it from material's root zoom, so it lands at the intended 14/13px at every width — without resetting the root (which would shrink all the page content).
  - This is very admittedly a stopgap approach. More careful alignment is needed between mkdocs and the design-system decisions, likely preceded by a decision if we are continuing to use mkdocs long-term.

### Preview

- fullpage size

<img width="1918" height="2040" alt="Screenshot from 2026-06-30 11-25-24" src="https://github.com/user-attachments/assets/ccffceef-166c-4d23-8f2e-d183b08a9803" />

- mobile magnify

<img width="576" height="241" alt="Screenshot from 2026-06-30 11-26-02" src="https://github.com/user-attachments/assets/ef478741-6f20-43f9-a8a4-3950ef6d7749" />
<img width="575" height="284" alt="Screenshot from 2026-06-30 11-26-12" src="https://github.com/user-attachments/assets/6d7b07f6-1d9c-42eb-98c1-7e02eaa3b355" />
