### PR TITLE
[ARXIVCE-4426] Restore site nav behavior of hamburger menu. Remove new button set.

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -69,18 +69,13 @@
     {#- info.arxiv.org subsite clarification (docs-only), uniform with the brand. -#}
     <span class="ds-site-header-subsite">arXiv info</span>
   </span>
-  <button type="button" id="ds-nav-toggle" class="ds-site-header-nav-toggle" aria-label="Open menu" aria-controls="ds-site-header-nav" aria-expanded="false">
+  {#- The header hamburger drives material's site-nav drawer on mobile/tablet (see the
+      unify script below). The shared Submit/Donate/Log in nav is dropped on the docs
+      site, so the shared arxiv-header.js hamburger wiring is a no-op. Shown below 1220px
+      (drawer) and hidden at/above (permanent sidebar), via extra.css. -#}
+  <button type="button" id="ds-nav-toggle" class="ds-site-header-nav-toggle" aria-label="Open navigation" aria-expanded="false">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
   </button>
-  <nav class="ds-site-header-nav" id="ds-site-header-nav" aria-label="Main navigation">
-    {#- On info.arxiv.org the spinout paper-search button is omitted to avoid
-        confusion with the site's own internal docs search, which is relocated
-        into this bar (see the unify script below). -#}
-    <a href="{{ config.extra.arxiv_host }}/user/create">Submit</a>
-    <a href="{{ config.extra.info_host }}/about/donate.html">Donate</a>
-    <span class="ds-site-header-divider" aria-hidden="true"></span>
-    <a href="{{ config.extra.arxiv_host }}/login" class="ds-site-header-login">Log in</a>
-  </nav>
 </header>
 
 {#- The spinout paper-search overlay is intentionally omitted on info.arxiv.org
@@ -187,6 +182,27 @@
       var searchToggle = md.querySelector('.md-header__button[for="__search"]');
       if (searchToggle) host.appendChild(searchToggle);
       bar.appendChild(host);
+      // Drive material's site-nav drawer (#__drawer, a pure-CSS toggle) from the header
+      // hamburger, and mirror aria-state however the drawer is toggled. Esc closes it.
+      var drawer = document.getElementById('__drawer');
+      var navToggle = document.getElementById('ds-nav-toggle');
+      if (drawer && navToggle) {
+        var setDrawer = function (open) {
+          drawer.checked = open;
+          drawer.dispatchEvent(new Event('change'));
+        };
+        navToggle.addEventListener('click', function (e) {
+          e.stopPropagation();
+          setDrawer(!drawer.checked);
+        });
+        drawer.addEventListener('change', function () {
+          navToggle.setAttribute('aria-expanded', drawer.checked);
+          navToggle.setAttribute('aria-label', drawer.checked ? 'Close navigation' : 'Open navigation');
+        });
+        document.addEventListener('keydown', function (e) {
+          if (e.key === 'Escape' && drawer.checked) { setDrawer(false); navToggle.focus(); }
+        });
+      }
       document.documentElement.classList.add('ds-docs-unified');
     }
     if (document.readyState !== 'loading') unify();

--- a/source/stylesheets/extra.css
+++ b/source/stylesheets/extra.css
@@ -96,13 +96,11 @@ body {
   flex-shrink: 0;
   margin-left: 8px;
 }
-/* The controls cluster is appended after the nav so it lands at the far right on
-   desktop. On mobile the nav collapses behind the hamburger but the cluster stays
-   visible; the hamburger comes earlier in the DOM, so bump its flex order to keep it
-   rightmost — yielding [theme toggle][search][hamburger]. (≤599px = the chrome's
-   collapsible breakpoint.) */
-@media (max-width: 599px) {
-  .ds-site-header #ds-nav-toggle { order: 10; }
+/* Show the header hamburger below 1220px, where material's primary sidebar is a
+   slide-in drawer (see the unify script in main.html). body prefix beats the chrome
+   default (display:none, loaded later); order keeps it rightmost after the controls. */
+@media (max-width: 1219.98px) {
+  body .ds-site-header .ds-site-header-nav-toggle { display: inline-flex; order: 10; }
 }
 /* relocated color-theme toggle — light glyphs on the black bar */
 .ds-site-header [data-md-component="palette"] { display: flex; align-items: center; }


### PR DESCRIPTION
As per today's feedback, info.arxiv.org is kept closer to its original header, mostly a reskin now. (Still sharing most of the new design system primitives)

### Preview (wide, medium, narrow)

- wide
<img width="2545" height="289" alt="Screenshot from 2026-07-01 10-55-09" src="https://github.com/user-attachments/assets/a25178a7-04dc-4f5a-acdc-3a70d914c1db" />

- medium

<img width="1266" height="288" alt="Screenshot from 2026-07-01 10-55-27" src="https://github.com/user-attachments/assets/ffcf7cd2-0b43-4d78-a4e8-0e18b842cd50" />

- narrow

<img width="256" alt="Screenshot from 2026-07-01 10-55-53" src="https://github.com/user-attachments/assets/17abca5a-47b0-4a85-81df-e440b8ba5d93" />


<img width="256" alt="Screenshot from 2026-07-01 10-55-59" src="https://github.com/user-attachments/assets/de497312-d49f-49eb-8b59-c22276845451" />
